### PR TITLE
Add permissions block in CI/CD and fix values.yaml syntax

### DIFF
--- a/.github/workflows/cost-splitting-report.yml
+++ b/.github/workflows/cost-splitting-report.yml
@@ -6,6 +6,9 @@ on:
 env:
   AWS_REGION: ${{ secrets.AWS_REGION }}
   BUCKET_NAME: ${{ secrets.BUCKET_NAME }}
+permissions:
+      id-token: write
+      contents: read 
 defaults:
   run:
     shell: bash

--- a/ckan-deployment/helm-templates/values.yaml.dev.template
+++ b/ckan-deployment/helm-templates/values.yaml.dev.template
@@ -33,10 +33,10 @@ ckan:
       CKAN__STORAGE_PATH: /tmp
       CKAN__VIEWS__DEFAULT_VIEWS: recline_view text_view image_view pdf_view geojson_view
       CKAN__PLUGINS: image_view text_view webpage_view resource_proxy datatables_view datastore datapusher activity envvars
-      CKAN__AUTH__CREATE_UNOWNED_DATASET: True
-      CKAN__AUTH__ALLOW_DATASET_COLLABORATORS: True
-      CKAN__AUTH__ALLOW_ADMIN_COLLABORATORS: True
-      CKAN__AUTH__ALLOW_COLLABORATORS_TO_CHANGE_OWNER_ORG: True
+      CKAN__AUTH__CREATE_UNOWNED_DATASET: "True"
+      CKAN__AUTH__ALLOW_DATASET_COLLABORATORS: "True"
+      CKAN__AUTH__ALLOW_ADMIN_COLLABORATORS: "True"
+      CKAN__AUTH__ALLOW_COLLABORATORS_TO_CHANGE_OWNER_ORG: "True"
     hpa:
       enable: true
       minReplicas: 2


### PR DESCRIPTION
This PR fixes the broken build due to permissions not present in the CI/CD and syntax error in the values.yaml file.