### PR TITLE
Enable scheming extension on test site

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 # WRI ODP
 
-The WRI Open Data Portal monorepo 
+The WRI Open Data Portal monorepo
 
 ## CKAN Backend Development
 

--- a/ckan-backend-dev/src/ckanext-wri/README.md
+++ b/ckan-backend-dev/src/ckanext-wri/README.md
@@ -8,7 +8,7 @@
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-# ckanext-wri 
+# ckanext-wri
 
 This is the WRI Open Data Portal extension for CKAN. It contains CKAN backend customizations for this project.
 

--- a/ckan-backend-dev/src/ckanext-wri/README.md
+++ b/ckan-backend-dev/src/ckanext-wri/README.md
@@ -8,7 +8,7 @@
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-# ckanext-wri
+# ckanext-wri 
 
 This is the WRI Open Data Portal extension for CKAN. It contains CKAN backend customizations for this project.
 

--- a/ckan-backend-dev/src/ckanext-wri/test.ini
+++ b/ckan-backend-dev/src/ckanext-wri/test.ini
@@ -8,8 +8,12 @@ use = config:../../src/ckan/test-core.ini
 
 # Insert any custom config settings to be used when running your extension's
 # tests here. These will override the one defined in CKAN core's test-core.ini
-ckan.plugins = wri
-
+ckan.plugins = wri scheming_datasets
+scheming.dataset_schemas = ckanext.wri.schema:ckan_dataset.yaml
+scheming.presets = ckanext.wri.schema:presets.json
+api_token.jwt.algorithm = RS256
+api_token.jwt.encode.secret = file:/srv/app/jwtRS256.key
+api_token.jwt.decode.secret = file:/srv/app/jwtRS256.key.pub
 
 # Logging configuration
 [loggers]

--- a/deployment/helm-templates/values.yaml.dev.template
+++ b/deployment/helm-templates/values.yaml.dev.template
@@ -32,12 +32,12 @@ ckan:
       CKAN__SITE_TITLE: x demo
       CKAN__STORAGE_PATH: /tmp
       CKAN__VIEWS__DEFAULT_VIEWS: recline_view text_view image_view pdf_view geojson_view
-      CKAN__PLUGINS: image_view text_view webpage_view resource_proxy datatables_view datastore datapusher activity s3filestore auth envvars
+      CKAN__PLUGINS: image_view text_view webpage_view resource_proxy datatables_view datastore datapusher activity s3filestore scheming_datasets scheming_organizations scheming_groups wri auth envvars
       CKAN__AUTH__CREATE_UNOWNED_DATASET: "True"
       CKAN__AUTH__ALLOW_DATASET_COLLABORATORS: "True"
       CKAN__AUTH__ALLOW_ADMIN_COLLABORATORS: "True"
       CKAN__AUTH__ALLOW_COLLABORATORS_TO_CHANGE_OWNER_ORG: "True"
-      CKAN___SCHEMING__DATASET_SCHEMAS: ckanext.scheming:ckan_dataset.yaml
+      CKAN___SCHEMING__DATASET_SCHEMAS: ckanext.wri.schema:ckan_dataset.yaml
       CKAN___SCHEMING__ORGANIZATION_SCHEMAS: ckanext.scheming:custom_org_with_address.json
       CKAN___SCHEMING__GROUP_SCHEMAS: ckanext.scheming:custom_group_with_status.json
       CKAN___SCHEMING__PRESETS: ckanext.wri.schema:presets.json


### PR DESCRIPTION
Enables `ckanext-scheming` and `ckanext-wri` in `values.yaml.dev.template`.
