### PR TITLE
Fix ckanext-auth

### DIFF
--- a/ckan-backend-dev/.env.example
+++ b/ckan-backend-dev/.env.example
@@ -46,11 +46,6 @@ CKAN_SITE_URL=http://ckan-dev:5000
 CKAN_PORT=5000
 CKAN_PORT_HOST=5000
 CKAN___BEAKER__SESSION__SECRET=CHANGE_ME
-# See https://docs.ckan.org/en/latest/maintaining/configuration.html#api-token-settings
-# Note: These tokens are only used in local development environments. There's no security risk here.
-CKAN___API_TOKEN__JWT__ALGORITHM=RS256
-CKAN___API_TOKEN__JWT__ENCODE__SECRET=file:/srv/app/jwtRS256.key
-CKAN___API_TOKEN__JWT__DECODE__SECRET=file:/srv/app/jwtRS256.key.pub
 CKAN_SYSADMIN_NAME=ckan_admin
 CKAN_SYSADMIN_PASSWORD=test1234
 CKAN_SYSADMIN_EMAIL=your_email@example.com

--- a/ckan-backend-dev/ckan/Dockerfile.dev
+++ b/ckan-backend-dev/ckan/Dockerfile.dev
@@ -27,7 +27,8 @@ RUN pip3 install -e 'git+https://github.com/datopian/ckanext-scheming.git@ckan-2
     pip3 install -e 'git+https://github.com/datopian/ckanext-s3filestore.git@wri/cost-splitting-orgs#egg=ckanext-s3filestore' && \
     pip3 install -r 'https://raw.githubusercontent.com/datopian/ckanext-s3filestore/wri/cost-splitting-orgs/requirements.txt' && \
     pip3 install -r 'https://raw.githubusercontent.com/datopian/ckanext-s3filestore/wri/cost-splitting-orgs/dev-requirements.txt' && \
-    pip3 install -e 'git+https://github.com/datopian/ckanext-auth.git@v2.10#egg=ckanext-auth'
+    # We're using the v2.10 branch of ckanext-auth, but I'm adding a commit to force a rebuild of the image. This can be removed once ckanext-auth is approved
+    pip3 install -e 'git+https://github.com/datopian/ckanext-auth.git@e45cccf43abbdf9d9069047e646b3e42307e81e1#egg=ckanext-auth'
 
 # Update ckanext-s3filestore test.ini with minio credentials
 RUN sed -i "s|ckanext.s3filestore.aws_access_key_id = test-access-key|ckanext.s3filestore.aws_access_key_id = ${AWS_ACCESS_KEY_ID}|g" src/ckanext-s3filestore/test.ini && \

--- a/ckan-backend-dev/ckan/Dockerfile.dev
+++ b/ckan-backend-dev/ckan/Dockerfile.dev
@@ -27,7 +27,7 @@ RUN pip3 install -e 'git+https://github.com/datopian/ckanext-scheming.git@ckan-2
     pip3 install -e 'git+https://github.com/datopian/ckanext-s3filestore.git@wri/cost-splitting-orgs#egg=ckanext-s3filestore' && \
     pip3 install -r 'https://raw.githubusercontent.com/datopian/ckanext-s3filestore/wri/cost-splitting-orgs/requirements.txt' && \
     pip3 install -r 'https://raw.githubusercontent.com/datopian/ckanext-s3filestore/wri/cost-splitting-orgs/dev-requirements.txt' && \
-    pip3 install -e 'git+https://github.com/datopian/ckanext-auth.git@v2.9#egg=ckanext-auth'
+    pip3 install -e 'git+https://github.com/datopian/ckanext-auth.git@v2.10#egg=ckanext-auth'
 
 # Update ckanext-s3filestore test.ini with minio credentials
 RUN sed -i "s|ckanext.s3filestore.aws_access_key_id = test-access-key|ckanext.s3filestore.aws_access_key_id = ${AWS_ACCESS_KEY_ID}|g" src/ckanext-s3filestore/test.ini && \
@@ -60,21 +60,5 @@ RUN chown ckan:ckan ${APP_DIR}/prerun.py
 COPY setup/start_ckan_development.sh.override ${APP_DIR}/start_ckan_development.sh
 RUN chmod +x ${APP_DIR}/start_ckan_development.sh
 RUN chown ckan:ckan ${APP_DIR}/start_ckan_development.sh
-
-#COPY setup/jwtRS256.key ${APP_DIR}/jwtRS256.key
-#COPY setup/jwtRS256.key.pub ${APP_DIR}/jwtRS256.key.pub
-#RUN chown ckan:ckan ${APP_DIR}/jwtRS256.key
-#RUN chown ckan:ckan ${APP_DIR}/jwtRS256.key.pub
-
-RUN apk --no-cache add openssl
-
-RUN openssl genpkey -algorithm RSA -out ${APP_DIR}/jwtRS256.key && \
-    openssl rsa -in ${APP_DIR}/jwtRS256.key -pubout -outform PEM -out ${APP_DIR}/jwtRS256.key.pub && \
-    chown ckan:ckan ${APP_DIR}/jwtRS256.key && \
-    chown ckan:ckan ${APP_DIR}/jwtRS256.key.pub
-
-#RUN ckan config-tool ${CKAN_INI} "api_token.jwt.algorithm = RS256" && \
-#    ckan config-tool ${CKAN_INI} "api_token.jwt.encode.secret = file:${APP_DIR}/jwtRS256.key" && \
-#    ckan config-tool ${CKAN_INI} "api_token.jwt.decode.secret = file:${APP_DIR}/jwtRS256.key.pub"
 
 CMD ["sh", "-c", "${APP_DIR}/start_ckan_development.sh"]

--- a/ckan-backend-dev/src/ckanext-wri/ckanext/wri/tests/test_schema.py
+++ b/ckan-backend-dev/src/ckanext-wri/ckanext/wri/tests/test_schema.py
@@ -1,15 +1,9 @@
 import pytest
 
-from ckanapi import RemoteCKAN
-
 from ckan.logic import NotFound, get_action, ValidationError
-from ckan.common import config
-import ckan.lib.navl.dictization_functions as df
 from ckan import model
 import ckan.tests.factories as factories
 from ckan.logic import get_action
-
-Invalid = df.Invalid
 
 
 @pytest.mark.usefixtures(u"with_plugins", u"test_request_context")

--- a/ckan-backend-dev/src/ckanext-wri/dev-requirements.txt
+++ b/ckan-backend-dev/src/ckanext-wri/dev-requirements.txt
@@ -1,2 +1,1 @@
 pytest-ckan
-ckanapi==4.7

--- a/deployment/ckan/Dockerfile
+++ b/deployment/ckan/Dockerfile
@@ -9,7 +9,8 @@ RUN pip3 install -e 'git+https://github.com/datopian/ckanext-scheming.git@ckan-2
     pip3 install -e 'git+https://github.com/datopian/ckanext-s3filestore.git@wri/cost-splitting-orgs#egg=ckanext-s3filestore' && \
     pip3 install -r 'https://raw.githubusercontent.com/datopian/ckanext-s3filestore/wri/cost-splitting-orgs/requirements.txt' && \
     pip3 install -r 'https://raw.githubusercontent.com/datopian/ckanext-s3filestore/wri/cost-splitting-orgs/dev-requirements.txt' && \
-    pip3 install -e 'git+https://github.com/datopian/ckanext-auth.git@v2.10#egg=ckanext-auth'
+    # We're using the v2.10 branch of ckanext-auth, but I'm adding a commit to force a rebuild of the image. This can be removed once ckanext-auth is approved
+    pip3 install -e 'git+https://github.com/datopian/ckanext-auth.git@e45cccf43abbdf9d9069047e646b3e42307e81e1#egg=ckanext-auth'
 
 COPY ckanext-wri ${APP_DIR}/src/ckanext-wri
 USER root

--- a/deployment/ckan/Dockerfile
+++ b/deployment/ckan/Dockerfile
@@ -9,7 +9,7 @@ RUN pip3 install -e 'git+https://github.com/datopian/ckanext-scheming.git@ckan-2
     pip3 install -e 'git+https://github.com/datopian/ckanext-s3filestore.git@wri/cost-splitting-orgs#egg=ckanext-s3filestore' && \
     pip3 install -r 'https://raw.githubusercontent.com/datopian/ckanext-s3filestore/wri/cost-splitting-orgs/requirements.txt' && \
     pip3 install -r 'https://raw.githubusercontent.com/datopian/ckanext-s3filestore/wri/cost-splitting-orgs/dev-requirements.txt' && \
-    pip3 install -e 'git+https://github.com/datopian/ckanext-auth.git@v2.9#egg=ckanext-auth'
+    pip3 install -e 'git+https://github.com/datopian/ckanext-auth.git@v2.10#egg=ckanext-auth'
 
 COPY ckanext-wri ${APP_DIR}/src/ckanext-wri
 USER root
@@ -29,15 +29,6 @@ RUN cd ${APP_DIR}/src/ckanext-wri && pip3 install -r requirements.txt && pip3 in
 ENV CKAN__PLUGINS image_view text_view webpage_view resource_proxy datatables_view datastore datapusher activity s3filestore scheming_datasets scheming_organizations scheming_groups wri auth envvars
 
 RUN ckan config-tool ${CKAN_INI} "ckan.plugins = ${CKAN__PLUGINS}"
-
-USER root
-RUN apk --no-cache add openssl
-USER ckan
-
-RUN openssl genpkey -algorithm RSA -out ${APP_DIR}/jwtRS256.key && \
-    openssl rsa -in ${APP_DIR}/jwtRS256.key -pubout -outform PEM -out ${APP_DIR}/jwtRS256.key.pub && \
-    chown ckan:ckan ${APP_DIR}/jwtRS256.key && \
-    chown ckan:ckan ${APP_DIR}/jwtRS256.key.pub
 
 COPY setup/prerun.py.override ${APP_DIR}/prerun.py
 USER root


### PR DESCRIPTION
This PR bumps the ckanext-auth to a CKAN 2.10 compatible version. The compatibility changes were made by me and should be reviewed, but there isn't a PR, as it lives on the `v2.10` branch. Please review the code on this branch before approving https://github.com/datopian/ckanext-auth/compare/master...v2.10

I've also removed the JWT token generation lines from the Dockerfiles. They're no longer needed.