### PR TITLE
Bump ckanext-auth; Add JWT token generation back in

### DIFF
--- a/ckan-backend-dev/.env.example
+++ b/ckan-backend-dev/.env.example
@@ -101,3 +101,6 @@ CKAN___SCHEMING__DATASET_SCHEMAS=ckanext.wri.schema:ckan_dataset.yaml
 CKAN___SCHEMING__ORGANIZATION_SCHEMAS=ckanext.scheming:custom_org_with_address.json
 CKAN___SCHEMING__GROUP_SCHEMAS=ckanext.scheming:custom_group_with_status.json
 CKAN___SCHEMING__PRESETS=ckanext.wri.schema:presets.json
+
+# auth
+CKANEXT__AUTH__INCLUDE_FRONTEND_LOGIN_TOKEN=True

--- a/ckan-backend-dev/ckan/Dockerfile.dev
+++ b/ckan-backend-dev/ckan/Dockerfile.dev
@@ -61,7 +61,11 @@ COPY setup/start_ckan_development.sh.override ${APP_DIR}/start_ckan_development.
 RUN chmod +x ${APP_DIR}/start_ckan_development.sh
 RUN chown ckan:ckan ${APP_DIR}/start_ckan_development.sh
 
+USER root
+
 RUN apk --no-cache add openssl
+
+USER ckan
 
 RUN openssl genpkey -algorithm RSA -out ${APP_DIR}/jwtRS256.key && \
     openssl rsa -in ${APP_DIR}/jwtRS256.key -pubout -outform PEM -out ${APP_DIR}/jwtRS256.key.pub && \

--- a/ckan-backend-dev/ckan/Dockerfile.dev
+++ b/ckan-backend-dev/ckan/Dockerfile.dev
@@ -27,8 +27,7 @@ RUN pip3 install -e 'git+https://github.com/datopian/ckanext-scheming.git@ckan-2
     pip3 install -e 'git+https://github.com/datopian/ckanext-s3filestore.git@wri/cost-splitting-orgs#egg=ckanext-s3filestore' && \
     pip3 install -r 'https://raw.githubusercontent.com/datopian/ckanext-s3filestore/wri/cost-splitting-orgs/requirements.txt' && \
     pip3 install -r 'https://raw.githubusercontent.com/datopian/ckanext-s3filestore/wri/cost-splitting-orgs/dev-requirements.txt' && \
-    # We're using the v2.10 branch of ckanext-auth, but I'm adding a commit to force a rebuild of the image. This can be removed once ckanext-auth is approved
-    pip3 install -e 'git+https://github.com/datopian/ckanext-auth.git@e45cccf43abbdf9d9069047e646b3e42307e81e1#egg=ckanext-auth'
+    pip3 install -e 'git+https://github.com/datopian/ckanext-auth.git@auth-object-return-token#egg=ckanext-auth'
 
 # Update ckanext-s3filestore test.ini with minio credentials
 RUN sed -i "s|ckanext.s3filestore.aws_access_key_id = test-access-key|ckanext.s3filestore.aws_access_key_id = ${AWS_ACCESS_KEY_ID}|g" src/ckanext-s3filestore/test.ini && \
@@ -61,5 +60,16 @@ RUN chown ckan:ckan ${APP_DIR}/prerun.py
 COPY setup/start_ckan_development.sh.override ${APP_DIR}/start_ckan_development.sh
 RUN chmod +x ${APP_DIR}/start_ckan_development.sh
 RUN chown ckan:ckan ${APP_DIR}/start_ckan_development.sh
+
+RUN apk --no-cache add openssl
+
+RUN openssl genpkey -algorithm RSA -out ${APP_DIR}/jwtRS256.key && \
+    openssl rsa -in ${APP_DIR}/jwtRS256.key -pubout -outform PEM -out ${APP_DIR}/jwtRS256.key.pub && \
+    chown ckan:ckan ${APP_DIR}/jwtRS256.key && \
+    chown ckan:ckan ${APP_DIR}/jwtRS256.key.pub
+
+RUN ckan config-tool ${CKAN_INI} "api_token.jwt.algorithm = RS256" && \
+    ckan config-tool ${CKAN_INI} "api_token.jwt.encode.secret = file:${APP_DIR}/jwtRS256.key" && \
+    ckan config-tool ${CKAN_INI} "api_token.jwt.decode.secret = file:${APP_DIR}/jwtRS256.key.pub"
 
 CMD ["sh", "-c", "${APP_DIR}/start_ckan_development.sh"]

--- a/deployment/ckan/Dockerfile
+++ b/deployment/ckan/Dockerfile
@@ -9,8 +9,7 @@ RUN pip3 install -e 'git+https://github.com/datopian/ckanext-scheming.git@ckan-2
     pip3 install -e 'git+https://github.com/datopian/ckanext-s3filestore.git@wri/cost-splitting-orgs#egg=ckanext-s3filestore' && \
     pip3 install -r 'https://raw.githubusercontent.com/datopian/ckanext-s3filestore/wri/cost-splitting-orgs/requirements.txt' && \
     pip3 install -r 'https://raw.githubusercontent.com/datopian/ckanext-s3filestore/wri/cost-splitting-orgs/dev-requirements.txt' && \
-    # We're using the v2.10 branch of ckanext-auth, but I'm adding a commit to force a rebuild of the image. This can be removed once ckanext-auth is approved
-    pip3 install -e 'git+https://github.com/datopian/ckanext-auth.git@e45cccf43abbdf9d9069047e646b3e42307e81e1#egg=ckanext-auth'
+    pip3 install -e 'git+https://github.com/datopian/ckanext-auth.git@auth-object-return-token#egg=ckanext-auth'
 
 COPY ckanext-wri ${APP_DIR}/src/ckanext-wri
 USER root
@@ -35,3 +34,14 @@ COPY setup/prerun.py.override ${APP_DIR}/prerun.py
 USER root
 RUN chmod +x ${APP_DIR}/prerun.py
 USER ckan
+
+RUN apk --no-cache add openssl
+
+RUN openssl genpkey -algorithm RSA -out ${APP_DIR}/jwtRS256.key && \
+    openssl rsa -in ${APP_DIR}/jwtRS256.key -pubout -outform PEM -out ${APP_DIR}/jwtRS256.key.pub && \
+    chown ckan:ckan ${APP_DIR}/jwtRS256.key && \
+    chown ckan:ckan ${APP_DIR}/jwtRS256.key.pub
+
+RUN ckan config-tool ${CKAN_INI} "api_token.jwt.algorithm = RS256" && \
+    ckan config-tool ${CKAN_INI} "api_token.jwt.encode.secret = file:${APP_DIR}/jwtRS256.key" && \
+    ckan config-tool ${CKAN_INI} "api_token.jwt.decode.secret = file:${APP_DIR}/jwtRS256.key.pub"

--- a/deployment/ckan/Dockerfile
+++ b/deployment/ckan/Dockerfile
@@ -33,9 +33,10 @@ RUN ckan config-tool ${CKAN_INI} "ckan.plugins = ${CKAN__PLUGINS}"
 COPY setup/prerun.py.override ${APP_DIR}/prerun.py
 USER root
 RUN chmod +x ${APP_DIR}/prerun.py
-USER ckan
 
 RUN apk --no-cache add openssl
+
+USER ckan
 
 RUN openssl genpkey -algorithm RSA -out ${APP_DIR}/jwtRS256.key && \
     openssl rsa -in ${APP_DIR}/jwtRS256.key -pubout -outform PEM -out ${APP_DIR}/jwtRS256.key.pub && \

--- a/deployment/helm-templates/values.yaml.dev.template
+++ b/deployment/helm-templates/values.yaml.dev.template
@@ -41,6 +41,7 @@ ckan:
       CKAN___SCHEMING__ORGANIZATION_SCHEMAS: ckanext.scheming:custom_org_with_address.json
       CKAN___SCHEMING__GROUP_SCHEMAS: ckanext.scheming:custom_group_with_status.json
       CKAN___SCHEMING__PRESETS: ckanext.wri.schema:presets.json
+      CKANEXT__AUTH__INCLUDE_FRONTEND_LOGIN_TOKEN: "True"
     hpa:
       enable: true
       minReplicas: 2


### PR DESCRIPTION
This PR bumps ckanext-auth to a custom branch that provides a user API token in the login response (required for frontend CRUD operations).

**Note**: I have to add back in the auto-generation of JWT tokens in the Dockerfiles. API token generation does not work properly without the JWT tokens being set up.

When reviewing this, please also review the code living in a custom branch in ckanext-auth (it may or may not end up in a PR for the ckanext-auth CKAN 2.10 branch eventually, but for now, we're not merging). Here's the commit for these changes https://github.com/datopian/ckanext-auth/commit/303ffc1ab2067863ba40143bb40de51887e5dd8d