### PR TITLE
[Fix]: fix short descriptor field collapsing into description field

### DIFF
--- a/deployment/frontend/src/components/dashboard/datasets/admin/metadata/DescriptionForm.tsx
+++ b/deployment/frontend/src/components/dashboard/datasets/admin/metadata/DescriptionForm.tsx
@@ -43,7 +43,7 @@ export function DescriptionForm({
                             </DefaultTooltip>
                         </div>
                     }
-                    className="mb-2 flex-col items-start whitespace-nowrap sm:grid-cols-1 grid-cols-1 sm:flex-col sm:items-start sm:gap-y-2"
+                    className="mb-2 flex  flex-col items-start whitespace-nowrap sm:flex-col"
                 >
                     <TextArea
                         placeholder=""


### PR DESCRIPTION
<img width="1787" alt="Screenshot 2024-01-08 at 17 11 49" src="https://github.com/wri/wri-odp/assets/20904032/32a955e6-e01a-426d-94eb-655b99a748e2">
