### PR TITLE
Fix usernames in notification emails

### DIFF
--- a/deployment/frontend/src/utils/apiUtils.ts
+++ b/deployment/frontend/src/utils/apiUtils.ts
@@ -1387,8 +1387,8 @@ async function sendNotification(
                 })
                 if (senderUserObj) {
                     const email = await generateMemberEmail(
-                        userObj,
                         senderUserObj,
+                        userObj,
                         notification as NotificationType
                     )
                     await sendEmail(


### PR DESCRIPTION
Small fix for member notification email usernames. They were swapped:

>Hi mp_admin,
>
>demousercreation-5889 added you as a member (admin) in the topic 33ivxzlfbnk-test-group-test.
>
>Have a great day!
>
>Sent by the WRI OpenData Platform

Should be:

>Hi demousercreation-5889,
>
>mp_admin added you as a member (admin) in the topic 33ivxzlfbnk-test-group-test.
>
>Have a great day!
>
>Sent by the WRI OpenData Platform