### PR TITLE
Increase nginx proxy buffer size and count

### DIFF
--- a/deployment/helm-templates/values.yaml.staging.template
+++ b/deployment/helm-templates/values.yaml.staging.template
@@ -144,6 +144,8 @@ ckan:
     useProductionCerts: true
   ingress:
     domain: wri.staging.ckan.datopian.com
+    proxyBufferSize: 128k
+    proxyBuffersNumber: 4
     enable: true
     enableExternal: false
     extraAnnotations:


### PR DESCRIPTION
This increases the proxy buffer size in nginx to 128k (should be large enough for most cases) and sets the buffer count to 4 (commonly used). This change will _hopefully_ resolve the SSO issues.