### PR TITLE
[Migration] Fallback to package_search by rw_id and application in case of duplicates

### DIFF
--- a/migration/main.py
+++ b/migration/main.py
@@ -7,17 +7,17 @@ import datetime
 import os
 
 
-DEPLOYMENT_ENV = os.environ['FLOW_DEPLOYMENT_ENV']
+DEPLOYMENT_ENV = os.environ["FLOW_DEPLOYMENT_ENV"]
 
 
 @flow
 def trigger_migration(data_dict):
     log = get_run_logger()
-    is_bulk = data_dict.get('is_bulk', False)
+    is_bulk = data_dict.get("is_bulk", False)
 
     if is_bulk:
-        start_time = datetime.datetime.now().strftime('%Y-%m-%d_%H:%M:%S')
-        dataset_csv = [['dataset_id', 'rw_url', 'ckan_url']]
+        start_time = datetime.datetime.now().strftime("%Y-%m-%d_%H:%M:%S")
+        dataset_csv = [["dataset_id", "rw_url", "ckan_url"]]
 
         datasets = get_datasets_from_csv()
 
@@ -28,34 +28,34 @@ def trigger_migration(data_dict):
             if rw_url and ckan_url:
                 dataset_csv.append([dataset_id, rw_url, ckan_url])
 
-        with open(f'flow_logs/bulk_migration_{start_time}.csv', 'w') as f:
+        with open(f"flow_logs/bulk_migration_{start_time}.csv", "w") as f:
             writer = csv.writer(f)
             writer.writerows(dataset_csv)
 
-        msg = 'Full migration task'
+        msg = "Full migration task"
 
     else:
-        start_time = datetime.datetime.now().strftime('%Y-%m-%d_%H:%M:%S')
+        start_time = datetime.datetime.now().strftime("%Y-%m-%d_%H:%M:%S")
         migration, rw_url, ckan_url, dataset_id = send_migration_dataset(data_dict)
 
         if rw_url and ckan_url:
-            with open(f'flow_logs/dataset_migration_{start_time}.csv', 'w') as f:
+            with open(f"flow_logs/dataset_migration_{start_time}.csv", "w") as f:
                 writer = csv.writer(f)
                 writer.writerows(
                     [
-                        ['dataset_id', 'rw_url', 'ckan_url'],
+                        ["dataset_id", "rw_url", "ckan_url"],
                         [dataset_id, rw_url, ckan_url],
                     ]
                 )
 
-        msg = 'Migration task'
+        msg = "Migration task"
 
     return msg
 
 
 if __name__ == "__main__":
     migration_deployment = trigger_migration.to_deployment(
-        name=f'migration_deployment_{DEPLOYMENT_ENV}',
+        name=f"migration_deployment_{DEPLOYMENT_ENV}",
         enforce_parameter_schema=False,
         is_schedule_active=False,
     )

--- a/migration/tasks/migration_task.py
+++ b/migration/tasks/migration_task.py
@@ -13,12 +13,12 @@ from xml.etree import ElementTree as ET
 import ckanapi
 
 
-DATASETS_FILE = 'files/datasets.csv'
-RW_API = 'https://api.resourcewatch.org/v1/dataset'
-DEPLOYMENT_ENV = os.environ['FLOW_DEPLOYMENT_ENV']
-CKAN_API_KEY = Secret.load(f'ckan-api-key-{DEPLOYMENT_ENV}').get()
-CKAN_URL = variables.get(f'ckan_url_{DEPLOYMENT_ENV}')
-FRONTEND_CKAN_URL = variables.get(f'ckan_frontend_url_{DEPLOYMENT_ENV}')
+DATASETS_FILE = "files/datasets.csv"
+RW_API = "https://api.resourcewatch.org/v1/dataset"
+DEPLOYMENT_ENV = os.environ["FLOW_DEPLOYMENT_ENV"]
+CKAN_API_KEY = Secret.load(f"ckan-api-key-{DEPLOYMENT_ENV}").get()
+CKAN_URL = variables.get(f"ckan_url_{DEPLOYMENT_ENV}")
+FRONTEND_CKAN_URL = variables.get(f"ckan_frontend_url_{DEPLOYMENT_ENV}")
 
 
 ckan = ckanapi.RemoteCKAN(CKAN_URL, apikey=CKAN_API_KEY)
@@ -26,25 +26,25 @@ ckan = ckanapi.RemoteCKAN(CKAN_URL, apikey=CKAN_API_KEY)
 
 def munge_title_to_name(name: str) -> str:
     # Taken from CKAN 2.10 codebase
-    '''Munge a package title into a package name.'''
+    """Munge a package title into a package name."""
     name = substitute_ascii_equivalents(name)
     # convert spaces and separators
-    name = re.sub('[ .:/]', '-', name)
+    name = re.sub("[ .:/]", "-", name)
     # take out not-allowed characters
-    name = re.sub('[^a-zA-Z0-9-_]', '', name).lower()
+    name = re.sub("[^a-zA-Z0-9-_]", "", name).lower()
     # remove doubles
-    name = re.sub('-+', '-', name)
+    name = re.sub("-+", "-", name)
     # remove leading or trailing hyphens
-    name = name.strip('-')
+    name = name.strip("-")
     # if longer than max_length, keep last word if a year
     max_length = 100
     # (make length less than max, in case we need a few for '_' chars
     # to de-clash names.)
     if len(name) > max_length:
-        year_match = re.match(r'.*?[_-]((?:\d{2,4}[-/])?\d{2,4})$', name)
+        year_match = re.match(r".*?[_-]((?:\d{2,4}[-/])?\d{2,4})$", name)
         if year_match:
             year = year_match.groups()[0]
-            name = '%s-%s' % (name[: (max_length - len(year) - 1)], year)
+            name = "%s-%s" % (name[: (max_length - len(year) - 1)], year)
         else:
             name = name[:max_length]
 
@@ -65,68 +65,68 @@ def substitute_ascii_equivalents(text_unicode: str) -> str:
     converted is deleted.
     """
     char_mapping = {
-        0xC0: 'A',
-        0xC1: 'A',
-        0xC2: 'A',
-        0xC3: 'A',
-        0xC4: 'A',
-        0xC5: 'A',
-        0xC6: 'Ae',
-        0xC7: 'C',
-        0xC8: 'E',
-        0xC9: 'E',
-        0xCA: 'E',
-        0xCB: 'E',
-        0xCC: 'I',
-        0xCD: 'I',
-        0xCE: 'I',
-        0xCF: 'I',
-        0xD0: 'Th',
-        0xD1: 'N',
-        0xD2: 'O',
-        0xD3: 'O',
-        0xD4: 'O',
-        0xD5: 'O',
-        0xD6: 'O',
-        0xD8: 'O',
-        0xD9: 'U',
-        0xDA: 'U',
-        0xDB: 'U',
-        0xDC: 'U',
-        0xDD: 'Y',
-        0xDE: 'th',
-        0xDF: 'ss',
-        0xE0: 'a',
-        0xE1: 'a',
-        0xE2: 'a',
-        0xE3: 'a',
-        0xE4: 'a',
-        0xE5: 'a',
-        0xE6: 'ae',
-        0xE7: 'c',
-        0xE8: 'e',
-        0xE9: 'e',
-        0xEA: 'e',
-        0xEB: 'e',
-        0xEC: 'i',
-        0xED: 'i',
-        0xEE: 'i',
-        0xEF: 'i',
-        0xF0: 'th',
-        0xF1: 'n',
-        0xF2: 'o',
-        0xF3: 'o',
-        0xF4: 'o',
-        0xF5: 'o',
-        0xF6: 'o',
-        0xF8: 'o',
-        0xF9: 'u',
-        0xFA: 'u',
-        0xFB: 'u',
-        0xFC: 'u',
-        0xFD: 'y',
-        0xFE: 'th',
-        0xFF: 'y',
+        0xC0: "A",
+        0xC1: "A",
+        0xC2: "A",
+        0xC3: "A",
+        0xC4: "A",
+        0xC5: "A",
+        0xC6: "Ae",
+        0xC7: "C",
+        0xC8: "E",
+        0xC9: "E",
+        0xCA: "E",
+        0xCB: "E",
+        0xCC: "I",
+        0xCD: "I",
+        0xCE: "I",
+        0xCF: "I",
+        0xD0: "Th",
+        0xD1: "N",
+        0xD2: "O",
+        0xD3: "O",
+        0xD4: "O",
+        0xD5: "O",
+        0xD6: "O",
+        0xD8: "O",
+        0xD9: "U",
+        0xDA: "U",
+        0xDB: "U",
+        0xDC: "U",
+        0xDD: "Y",
+        0xDE: "th",
+        0xDF: "ss",
+        0xE0: "a",
+        0xE1: "a",
+        0xE2: "a",
+        0xE3: "a",
+        0xE4: "a",
+        0xE5: "a",
+        0xE6: "ae",
+        0xE7: "c",
+        0xE8: "e",
+        0xE9: "e",
+        0xEA: "e",
+        0xEB: "e",
+        0xEC: "i",
+        0xED: "i",
+        0xEE: "i",
+        0xEF: "i",
+        0xF0: "th",
+        0xF1: "n",
+        0xF2: "o",
+        0xF3: "o",
+        0xF4: "o",
+        0xF5: "o",
+        0xF6: "o",
+        0xF8: "o",
+        0xF9: "u",
+        0xFA: "u",
+        0xFB: "u",
+        0xFC: "u",
+        0xFD: "y",
+        0xFE: "th",
+        0xFF: "y",
         # 0xa1: '!', 0xa2: '{cent}', 0xa3: '{pound}', 0xa4: '{currency}',
         # 0xa5: '{yen}', 0xa6: '|', 0xa7: '{section}', 0xa8: '{umlaut}',
         # 0xa9: '{C}', 0xaa: '{^a}', 0xab: '<<', 0xac: '{not}',
@@ -138,7 +138,7 @@ def substitute_ascii_equivalents(text_unicode: str) -> str:
         # 0xd7: '*', 0xf7: '/'
     }
 
-    r = ''
+    r = ""
     for char in text_unicode:
         if ord(char) in char_mapping:
             r += char_mapping[ord(char)]
@@ -157,7 +157,7 @@ def iso_language_code(value):
     """
     log = get_run_logger()
 
-    error_message = ''
+    error_message = ""
 
     if value and isinstance(value, str):
         try:
@@ -165,18 +165,18 @@ def iso_language_code(value):
 
             if not is_lang:
                 error_message = (
-                    f'Value must be a valid ISO 639-1 language code: {value}'
+                    f"Value must be a valid ISO 639-1 language code: {value}"
                 )
 
         except Exception as e:
-            error_message = f'Error validating language code: {e}'
+            error_message = f"Error validating language code: {e}"
     else:
-        error_message = 'Language code is not a string or is empty'
+        error_message = "Language code is not a string or is empty"
 
     if error_message:
         log.error(error_message)
 
-        return ''
+        return ""
     else:
         return value
 
@@ -190,21 +190,21 @@ def url_validator(value):
     """
     log = get_run_logger()
 
-    error_message = ''
+    error_message = ""
 
-    if value in [None, '']:
+    if value in [None, ""]:
         return value
 
     if isinstance(value, str):
-        if not value.startswith('http://') and not value.startswith('https://'):
+        if not value.startswith("http://") and not value.startswith("https://"):
             error_message = 'Value must start with "http://" or "https://"'
     else:
-        error_message = 'URL is not a string'
+        error_message = "URL is not a string"
 
     if error_message:
         log.error(error_message)
 
-        return ''
+        return ""
     else:
         return value
 
@@ -214,25 +214,45 @@ def normalize_value(value):
     Normalize value to string and strip whitespace.
     """
     if value is None:
-        return 'None'
+        return "None"
 
     if not isinstance(value, str):
         value = str(value)
 
-    if value in ['True', 'False']:
+    if value in ["True", "False"]:
         value = value.lower()
 
     return value.strip()
 
 
-def check_dataset_exists(dataset_id):
+def check_dataset_exists(dataset_id, rw_id=None, application=None):
     """
     Check if dataset exists in CKAN.
     """
+    log = get_run_logger()
     try:
         dataset = ckan.action.package_show(id=dataset_id)
         return True, dataset
     except ckanapi.errors.NotFound:
+        if rw_id and application:
+            dataset = ckan.action.package_search(
+                fq=f"+rw_id:{rw_id} +application:{application}"
+            )
+
+            dataset_count = dataset.get("count")
+            dataset_results = dataset.get("results")
+
+            if dataset_count > 1:
+                log.warning(f"Multiple datasets found with rw_id: {rw_id}")
+                log.warning("Datasets:")
+
+                for result in dataset_results:
+                    log.warning(f"  - {result.get('name')}")
+
+                log.warning("Using the first dataset found.")
+
+            return dataset_count > 0, dataset_results[0] if dataset_count > 0 else None
+
         return False, None
 
 
@@ -241,25 +261,25 @@ def get_datasets_from_csv():
     """
     Read datasets from CSV file.
     """
-    with open(DATASETS_FILE, 'r', encoding='utf-8-sig') as f:
+    with open(DATASETS_FILE, "r", encoding="utf-8-sig") as f:
         reader = csv.DictReader(f)
         datasets = []
 
         for row in reader:
             dataset = {}
-            dataset_id = row['datasetId']
-            application = row['application']
-            team = row.get('team')
-            topics = row.get('topics')
+            dataset_id = row["datasetId"]
+            application = row["application"]
+            team = row.get("team")
+            topics = row.get("topics")
 
             if topics:
-                topics = topics.split(',')
+                topics = topics.split(",")
 
             dataset = {
-                'id': dataset_id,
-                'application': application,
-                'team': team,
-                'topics': topics,
+                "id": dataset_id,
+                "application": application,
+                "team": team,
+                "topics": topics,
             }
             datasets.append(dataset)
 
@@ -268,29 +288,29 @@ def get_datasets_from_csv():
 
 @task(retries=10, retry_delay_seconds=5)
 def send_migration_dataset(data_dict):
-    dataset_id = data_dict.get('id')
-    application = data_dict.get('application')
-    team = data_dict.get('team')
-    topics = data_dict.get('topics')
+    dataset_id = data_dict.get("id")
+    application = data_dict.get("application")
+    team = data_dict.get("team")
+    topics = data_dict.get("topics")
     dataset = get_dataset_from_api(dataset_id, application)
-    whitelist = data_dict.get('whitelist')
-    blacklist = data_dict.get('blacklist')
+    whitelist = data_dict.get("whitelist")
+    blacklist = data_dict.get("blacklist")
 
-    dataset_slug = dataset.get('dataset', {}).get('slug')
+    dataset_slug = dataset.get("dataset", {}).get("slug")
 
     rw_dataset_url = None
 
     if dataset_slug:
-        rw_dataset_url = f'https://resourcewatch.org/data/explore/{dataset_slug}'
+        rw_dataset_url = f"https://resourcewatch.org/data/explore/{dataset_slug}"
 
     dataset = prepare_dataset(dataset, application, team, topics, whitelist, blacklist)
 
-    dataset_name = dataset.get('name')
+    dataset_name = dataset.get("name")
 
     ckan_dataset_url = None
 
     if dataset_name:
-        ckan_dataset_url = f'{FRONTEND_CKAN_URL}/datasets/{dataset_name}'
+        ckan_dataset_url = f"{FRONTEND_CKAN_URL}/datasets/{dataset_name}"
 
     return migrate_dataset(dataset), rw_dataset_url, ckan_dataset_url, dataset_id
 
@@ -298,107 +318,119 @@ def send_migration_dataset(data_dict):
 def migrate_dataset(data_dict):
     log = get_run_logger()
 
-    dataset_exists, dataset = check_dataset_exists(data_dict.get('name'))
-    dataset_name = data_dict.get('name')
+    dataset_name = data_dict.get("name")
+    dataset_exists, dataset = check_dataset_exists(
+        dataset_name, data_dict.get("rw_id"), data_dict.get("application")
+    )
+
     log_name = f'{dataset_name if dataset_name else "Unknown dataset"} -'
 
-    msg = 'Dataset migrated'
+    msg = "Dataset migrated"
 
     if not dataset_exists:
         try:
             ckan.action.package_create(**data_dict)
-            log.info(f'{log_name} Dataset created')
+            log.info(f"{log_name} Dataset created")
         except ckanapi.errors.ValidationError as e:
-            log.error(f'{log_name} Validation error: {e}')
-            log.error(f'{log_name} Dataset:', json.dumps(data_dict, indent=2))
+            log.error(f"{log_name} Validation error: {e}")
+            log.error(f"{log_name} Dataset:", json.dumps(data_dict, indent=2))
             raise e
     else:
-        log.info(f'{log_name} Dataset already exists')
+        log.info(f"{log_name} Dataset already exists")
 
         updated_dataset = {}
         dataset_changed = False
 
         for key, value in data_dict.items():
             if dataset.get(key) != value and key not in [
-                'resources',
-                'extras',
-                'groups',
-                'organization',
-                'owner_org_name',
+                "resources",
+                "extras",
+                "groups",
+                "organization",
+                "owner_org_name",
             ]:
                 dataset_changed = True
+                log.info(f"{log_name} {key} changed: {dataset.get(key)} -> {value}")
                 updated_dataset[key] = value
 
         if dataset_changed:
-            log.info(f'{log_name} Dataset changed...')
+            log.info(f"{log_name} Dataset changed...")
 
-        existing_groups = dataset.get('groups', [])
-        new_groups = data_dict.get('groups', [])
+        existing_groups = dataset.get("groups", [])
+        new_groups = data_dict.get("groups", [])
 
         if len(existing_groups) != len(new_groups) or any(
-            group.get('name') not in [g.get('name') for g in new_groups]
+            group.get("name") not in [g.get("name") for g in new_groups]
             for group in existing_groups
         ):
-            log.info(f'{log_name} Topics changed...')
-            log.info(f'{log_name} Existing topics: {json.dumps(existing_groups, indent=2)}')
-            log.info(f'{log_name} New topics: {json.dumps(new_groups, indent=2)}')
-            updated_dataset['groups'] = new_groups
+            log.info(f"{log_name} Topics changed...")
+            log.info(
+                f"{log_name} Existing topics: {json.dumps(existing_groups, indent=2)}"
+            )
+            log.info(f"{log_name} New topics: {json.dumps(new_groups, indent=2)}")
+            updated_dataset["groups"] = new_groups
         else:
-            log.info(f'{log_name} No topic changes')
+            log.info(f"{log_name} No topic changes")
 
         existing_organization = (
-            dataset.get('organization', {}).get('name')
-            if isinstance(dataset.get('organization'), dict)
+            dataset.get("organization", {}).get("name")
+            if isinstance(dataset.get("organization"), dict)
             else None
         )
         new_organization = (
-            data_dict.get('organization', {}).get('name')
-            if isinstance(data_dict.get('organization'), dict)
-            else data_dict.get('owner_org_name')
+            data_dict.get("organization", {}).get("name")
+            if isinstance(data_dict.get("organization"), dict)
+            else data_dict.get("owner_org_name")
         )
 
         if existing_organization != new_organization:
-            log.info(f'{log_name} Team changed...')
-            log.info(f'{log_name} Existing team: {existing_organization}')
-            log.info(f'{log_name} New team: {new_organization}')
+            log.info(f"{log_name} Team changed...")
+            log.info(f"{log_name} Existing team: {existing_organization}")
+            log.info(f"{log_name} New team: {new_organization}")
 
             if new_organization:
                 try:
                     owner_org = ckan.action.organization_show(id=new_organization)
-                    updated_dataset['owner_org'] = owner_org['id']
+                    updated_dataset["owner_org"] = owner_org["id"]
                 except (ckanapi.errors.NotFound, ckanapi.errors.ValidationError):
-                    log.error(f'{log_name} Team not found: {new_organization}')
+                    log.error(f"{log_name} Team not found: {new_organization}")
             else:
-                log.info('Team removed')
-                updated_dataset['owner_org'] = ''
+                log.info("Team removed")
+                updated_dataset["owner_org"] = ""
 
-        existing_extras = dataset.get('extras', [])
-        existing_migration_extras = dataset.get('migration_extras', {})
-        new_extras = data_dict.get('extras', [])
-        new_migration_extras = data_dict.get('migration_extras', {})
+        existing_extras = dataset.get("extras", [])
+        existing_migration_extras = dataset.get("migration_extras", {})
+        new_extras = data_dict.get("extras", [])
+        new_migration_extras = data_dict.get("migration_extras", {})
         normalized_existing_extras = {
-            extra.get('key'): normalize_value(extra.get('value'))
+            extra.get("key"): normalize_value(extra.get("value"))
             for extra in existing_extras
         }
         normalized_existing_migration_extras = {
-            key: normalize_value(value) for key, value in existing_migration_extras.items()
+            key: normalize_value(value)
+            for key, value in existing_migration_extras.items()
         }
         normalized_new_migration_extras = {
             key: normalize_value(value) for key, value in new_migration_extras.items()
         }
 
-        for key, value in normalized_new_migration_extras.items():
-            if normalized_existing_extras.get(key) == value:
-                del normalized_existing_extras[key]
+        old_migration_extras = []
+        old_extras = []
 
-        if len(normalized_existing_extras) != len(existing_extras):
-            log.info(f'{log_name} Found old migration_extras in extras. Removing...')
-            log.info(f'{log_name} Existing extras: {json.dumps(existing_extras, indent=2)}')
-            log.info(f'{log_name} New extras: {json.dumps(new_extras, indent=2)}')
-            updated_extras = [
-                {'key': key, 'value': value} for key, value in normalized_existing_extras.items()
-            ]
-            updated_dataset['extras'] = updated_extras
+        for extra in normalized_existing_extras:
+            if not (extra.startswith("dataset.") or extra.startswith("metadata.")):
+                old_extras.append(extra)
+            else:
+                old_migration_extras.append(extra)
+
+        if old_migration_extras:
+            log.info(f"{log_name} Found old migration_extras in extras. Removing...")
+            log.info(
+                f"{log_name} Existing extras: {json.dumps(existing_extras, indent=2)}"
+            )
+            log.info(f"{log_name} New extras: {json.dumps(new_extras, indent=2)}")
+
+            updated_dataset["extras"] = old_extras
 
         if (len(existing_migration_extras) != len(new_migration_extras)) or (
             any(
@@ -407,20 +439,22 @@ def migrate_dataset(data_dict):
                 for key in new_migration_extras
             )
         ):
-            log.info(f'{log_name} Migration extras changed...')
+            log.info(f"{log_name} Migration extras changed...")
             log.info(
-                f'{log_name} Existing migration extras: {json.dumps(existing_migration_extras, indent=2)}'
+                f"{log_name} Existing migration extras: {json.dumps(existing_migration_extras, indent=2)}"
             )
-            log.info(f'{log_name} New migration extras: {json.dumps(new_migration_extras, indent=2)}')
-            updated_dataset['migration_extras'] = new_migration_extras
+            log.info(
+                f"{log_name} New migration extras: {json.dumps(new_migration_extras, indent=2)}"
+            )
+            updated_dataset["migration_extras"] = new_migration_extras
         else:
-            log.info(f'{log_name} No migration extras changes')
+            log.info(f"{log_name} No migration extras changes")
 
-        existing_resources = dataset.get('resources', [])
-        new_resources = data_dict.get('resources', [])
-        new_layers_by_id = {r.get('rw_id'): r for r in new_resources if r.get('rw_id')}
+        existing_resources = dataset.get("resources", [])
+        new_resources = data_dict.get("resources", [])
+        new_layers_by_id = {r.get("rw_id"): r for r in new_resources if r.get("rw_id")}
         existing_layers_by_id = {
-            r.get('rw_id'): r for r in existing_resources if r.get('rw_id')
+            r.get("rw_id"): r for r in existing_resources if r.get("rw_id")
         }
 
         updated_resources = []
@@ -428,10 +462,10 @@ def migrate_dataset(data_dict):
         for rw_id, existing_resource in existing_layers_by_id.items():
             if rw_id in new_layers_by_id:
                 new_resource = new_layers_by_id[rw_id]
-                rw_fields = ['rw_id', 'url', 'type', 'url_type', 'name']
+                rw_fields = ["rw_id", "url", "type", "url_type", "name"]
                 updated_resource = {
-                    'id': existing_resource.get('id'),
-                    'package_id': existing_resource.get('package_id'),
+                    "id": existing_resource.get("id"),
+                    "package_id": existing_resource.get("package_id"),
                 }
 
                 for field in rw_fields:
@@ -443,48 +477,53 @@ def migrate_dataset(data_dict):
                 del new_layers_by_id[rw_id]
 
         for rw_id, new_resource in new_layers_by_id.items():
-            new_resource['package_id'] = dataset.get('id')
+            new_resource["package_id"] = dataset.get("id")
             updated_resources.append(new_resource)
 
         resource_changes = True
         remove_resources = existing_resources and not new_resources
 
-        if all(
-            len(updated_resource) == 2
-            and all(k in updated_resource for k in ['id', 'package_id'])
-            for updated_resource in updated_resources
-        ) and not remove_resources:
+        if (
+            all(
+                len(updated_resource) == 2
+                and all(k in updated_resource for k in ["id", "package_id"])
+                for updated_resource in updated_resources
+            )
+            and not remove_resources
+        ):
             resource_changes = False
 
         if resource_changes:
-            log.info(f'{log_name} Resources/layers changed...')
-            log.info(f'{log_name} Existing resources: {json.dumps(existing_resources, indent=2)}')
-            log.info(f'{log_name} New resources: {json.dumps(new_resources, indent=2)}')
+            log.info(f"{log_name} Resources/layers changed...")
+            log.info(
+                f"{log_name} Existing resources: {json.dumps(existing_resources, indent=2)}"
+            )
+            log.info(f"{log_name} New resources: {json.dumps(new_resources, indent=2)}")
 
             if updated_resources:
-                updated_dataset['resources'] = updated_resources
+                updated_dataset["resources"] = updated_resources
             elif remove_resources:
-                updated_dataset['resources'] = []
+                updated_dataset["resources"] = []
         else:
-            log.info(f'{log_name} No resource/layer changes')
+            log.info(f"{log_name} No resource/layer changes")
 
         if updated_dataset:
-            updated_dataset['id'] = dataset.get('id')
-            log.info(f'{log_name} Updating dataset')
+            updated_dataset["id"] = dataset.get("id")
+            log.info(f"{log_name} Updating dataset")
 
             try:
                 ckan.action.package_patch(**updated_dataset)
-                log.info(f'{log_name} Dataset updated: {dataset_name}')
+                log.info(f"{log_name} Dataset updated: {dataset_name}")
             except ckanapi.errors.ValidationError as e:
-                log.error(f'{log_name} Validation error: {e}')
+                log.error(f"{log_name} Validation error: {e}")
                 log.error(
-                    f'{log_name} Dataset: {json.dumps(updated_dataset, indent=2)}'
+                    f"{log_name} Dataset: {json.dumps(updated_dataset, indent=2)}"
                 )
                 raise e
         else:
-            log.info(f'{log_name} No changes required for dataset')
+            log.info(f"{log_name} No changes required for dataset")
 
-    log.info(f'{log_name} FINISHED DATASET MIGRATION')
+    log.info(f"{log_name} FINISHED DATASET MIGRATION")
 
     return msg
 
@@ -492,17 +531,17 @@ def migrate_dataset(data_dict):
 def get_paths(data):
     paths = []
 
-    for key in ['metadata', 'dataset']:
+    for key in ["metadata", "dataset"]:
         for inner_key, inner_value in data[key].items():
-            full_path = f'{key}.{inner_key}'
+            full_path = f"{key}.{inner_key}"
 
             if isinstance(inner_value, dict):
-                if inner_key not in ['info', 'resource']:
+                if inner_key not in ["info", "resource"]:
                     continue
 
-                if inner_key == 'info':
+                if inner_key == "info":
                     for info_key, info_value in inner_value.items():
-                        if info_key == 'sources' and isinstance(info_value, list):
+                        if info_key == "sources" and isinstance(info_value, list):
                             for index, source in enumerate(info_value):
                                 for source_key, source_value in source.items():
                                     paths.append(
@@ -516,13 +555,13 @@ def get_paths(data):
                             info_value, list
                         ):
                             paths.append((f"{full_path}.{info_key}", info_value))
-                if inner_key == 'resource':
+                if inner_key == "resource":
                     for resource_key, resource_value in inner_value.items():
                         paths.append((f"{full_path}.{resource_key}", resource_value))
                 continue
 
             if isinstance(inner_value, list):
-                if inner_key == 'application':
+                if inner_key == "application":
                     for index, item in enumerate(inner_value):
                         if not isinstance(item, dict):
                             paths.append((f"{full_path}.{index}", item))
@@ -536,58 +575,58 @@ def get_paths(data):
 def get_dataset_from_api(dataset_id, application):
     log = get_run_logger()
 
-    url = f'{RW_API}/{dataset_id}/metadata'
+    url = f"{RW_API}/{dataset_id}/metadata"
     response = requests.get(url)
-    output_object = {'metadata': {}, 'dataset': {}}
+    output_object = {"metadata": {}, "dataset": {}}
 
     if response.status_code == 200:
-        datasets = response.json()['data']
+        datasets = response.json()["data"]
 
         if datasets:
             metadata = [
                 m
                 for m in datasets
-                if m['attributes']['application'] == application
-                and m['attributes']['language'] == 'en'
+                if m["attributes"]["application"] == application
+                and m["attributes"]["language"] == "en"
             ]
 
             if len(metadata) > 0:
-                full_metadata = metadata[0].get('attributes', {})
+                full_metadata = metadata[0].get("attributes", {})
                 output_metadata = {}
 
                 for key, value in full_metadata.items():
-                    if key in ['resource', 'info'] or type(value) != dict:
+                    if key in ["resource", "info"] or type(value) != dict:
                         output_metadata[key] = value
 
-                output_object['metadata'] = output_metadata
+                output_object["metadata"] = output_metadata
 
-                if output_object['metadata']:
-                    output_object['metadata']['dataset_id'] = metadata[0]['id']
-                    output_object['metadata']['dataset_type'] = metadata[0]['type']
+                if output_object["metadata"]:
+                    output_object["metadata"]["dataset_id"] = metadata[0]["id"]
+                    output_object["metadata"]["dataset_type"] = metadata[0]["type"]
     else:
-        log.error(f'Error: {response.status_code} - {response.text}')
-        raise Exception(f'Error: {response.status_code} - {response.text}')
+        log.error(f"Error: {response.status_code} - {response.text}")
+        raise Exception(f"Error: {response.status_code} - {response.text}")
 
-    resource_url = f'{RW_API}/{dataset_id}?includes=layer'
+    resource_url = f"{RW_API}/{dataset_id}?includes=layer"
     resource_response = requests.get(resource_url)
 
     if resource_response.status_code == 200:
-        resource = resource_response.json()['data']
-        full_resource = resource.get('attributes', {})
+        resource = resource_response.json()["data"]
+        full_resource = resource.get("attributes", {})
         output_resource = {}
 
         for key, value in full_resource.items():
             if type(value) != dict:
                 output_resource[key] = value
 
-        output_object['dataset'] = output_resource
-        output_object['dataset']['dataset_id'] = resource['id']
-        output_object['dataset']['dataset_type'] = resource['type']
-        output_object['dataset']['requested_application'] = application.lower()
+        output_object["dataset"] = output_resource
+        output_object["dataset"]["dataset_id"] = resource["id"]
+        output_object["dataset"]["dataset_type"] = resource["type"]
+        output_object["dataset"]["requested_application"] = application.lower()
     else:
-        log.error(f'Error: {resource_response.status_code} - {resource_response.text}')
+        log.error(f"Error: {resource_response.status_code} - {resource_response.text}")
         raise Exception(
-            f'Error: {resource_response.status_code} - {resource_response.text}'
+            f"Error: {resource_response.status_code} - {resource_response.text}"
         )
 
     return output_object
@@ -598,38 +637,38 @@ def prepare_dataset(
 ):
     log = get_run_logger()
 
-    def get_value(key, default='', data_object=None):
+    def get_value(key, default="", data_object=None):
         data_objects = [dataset, resource]
 
-        if data_object == 'dataset':
+        if data_object == "dataset":
             data_objects = data_objects[::-1]
 
         for data_object in data_objects:
             if (
                 data_object
                 and key in data_object
-                and data_object[key] not in [None, '']
+                and data_object[key] not in [None, ""]
             ):
                 return data_object[key]
 
         return default
 
-    resource = data_dict.get('dataset', {})
-    dataset = data_dict.get('metadata', {})
+    resource = data_dict.get("dataset", {})
+    dataset = data_dict.get("metadata", {})
 
     if dataset:
-        dataset = {**dataset, **dataset.get('info', {})}
+        dataset = {**dataset, **dataset.get("info", {})}
 
     base_name = f'{get_value("name", data_object="dataset")}'
 
-    dataset_application = get_value('application')
+    dataset_application = get_value("application")
     requested_application = application
 
     warnings = []
 
     if not requested_application:
         warnings.append(
-            f'Requested application not found, using application: {application}'
+            f"Requested application not found, using application: {application}"
         )
         requested_application = dataset_application
 
@@ -638,81 +677,79 @@ def prepare_dataset(
 
         if requested_application not in application:
             warnings.append(
-                f'Requested application not found in dataset applications: {application}'
+                f"Requested application not found in dataset applications: {application}"
             )
-            warnings.append(f'Requested application: {requested_application}')
+            warnings.append(f"Requested application: {requested_application}")
 
     application = requested_application
 
-    name = munge_title_to_name(f'{base_name} {application}')
+    name = munge_title_to_name(f"{base_name} {application}")
 
     log_name = f'{name if name else "Unknown dataset"} -'
 
-    log.info(f'{log_name} STARTING MIGRATION')
-    log.info(f'{log_name} Beginning preparation...')
+    log.info(f"{log_name} STARTING MIGRATION")
+    log.info(f"{log_name} Beginning preparation...")
 
     for warning in warnings:
         log.warning(warning)
 
-    layers = resource.get('layer')
-    description = get_value('description')
-    title = get_value('name') or base_name
-    cautions = get_value('cautions')
-    language = get_value('language')
+    layers = resource.get("layer")
+    description = get_value("description")
+    title = get_value("name") or base_name
+    cautions = get_value("cautions")
+    language = get_value("language")
 
     if language:
         language = iso_language_code(language)
 
-    citation = get_value('citation')
-    learn_more_link = get_value('learn_more_link')
+    citation = get_value("citation")
+    learn_more_link = get_value("learn_more_link")
     function = (
-        get_value('function')
-        if get_value('function', False) not in [None, '']
-        else get_value('functions')
+        get_value("function")
+        if get_value("function", False) not in [None, ""]
+        else get_value("functions")
     )
     data_download_link = url_validator(
-        get_value('data_download_original_link')
-        if get_value('data_download_original_link', False) not in [None, '']
-        else get_value('data_download_link')
+        get_value("data_download_original_link")
+        if get_value("data_download_original_link", False) not in [None, ""]
+        else get_value("data_download_link")
     )
 
-    extras = dataset.get('extras', [])
+    extras = dataset.get("extras", [])
 
-    migration_extras = {
-        p[0]: normalize_value(p[1]) for p in set(get_paths(data_dict))
-    }
+    migration_extras = {p[0]: normalize_value(p[1]) for p in set(get_paths(data_dict))}
 
     required_dataset_values = {
-        'name': name,
-        'private': False,
-        'approval_status': 'approved',
-        'is_approved': True,
-        'draft': False,
-        'private': False,
-        'application': application,
-        'visibility_type': 'public',
+        "name": name,
+        "private": False,
+        "approval_status": "approved",
+        "is_approved": True,
+        "draft": False,
+        "private": False,
+        "application": application,
+        "visibility_type": "public",
     }
 
-    html_notes = markdown.markdown(description) if description else ''
-    short_description = ''
+    html_notes = markdown.markdown(description) if description else ""
+    short_description = ""
 
     if html_notes:
-        tree = ET.fromstring(f'<root>{html_notes}</root>')
-        short_description = ''.join(tree.itertext())
+        tree = ET.fromstring(f"<root>{html_notes}</root>")
+        short_description = "".join(tree.itertext())
 
     dataset_values = {
-        'title': title,
-        'notes': html_notes,
-        'short_description': short_description,
-        'migration_extras': migration_extras,
-        'extras': extras,
-        'cautions': markdown.markdown(cautions) if cautions else '',
-        'language': language,
-        'citation': citation,
-        'function': markdown.markdown(function) if function else '',
-        'url': data_download_link,
-        'learn_more': learn_more_link,
-        'update_frequency': '',
+        "title": title,
+        "notes": html_notes,
+        "short_description": short_description,
+        "migration_extras": migration_extras,
+        "extras": extras,
+        "cautions": markdown.markdown(cautions) if cautions else "",
+        "language": language,
+        "citation": citation,
+        "function": markdown.markdown(function) if function else "",
+        "url": data_download_link,
+        "learn_more": learn_more_link,
+        "update_frequency": "",
     }
 
     dataset_dict = {key: value for key, value in dataset_values.items() if value}
@@ -720,10 +757,10 @@ def prepare_dataset(
     if team:
         try:
             owner_org = ckan.action.organization_show(id=team)
-            required_dataset_values['owner_org'] = owner_org['id']
-            required_dataset_values['owner_org_name'] = owner_org['name']
+            required_dataset_values["owner_org"] = owner_org["id"]
+            required_dataset_values["owner_org_name"] = owner_org["name"]
         except ckanapi.errors.NotFound:
-            log.error(f'{log_name} Team not found: {team}')
+            log.error(f"{log_name} Team not found: {team}")
 
     if topics:
         valid_topics = []
@@ -731,35 +768,35 @@ def prepare_dataset(
         for topic in topics:
             try:
                 group = ckan.action.group_show(id=topic)
-                valid_topics.append({'name': group['name']})
+                valid_topics.append({"name": group["name"]})
             except ckanapi.errors.NotFound:
-                log.error(f'{log_name} Topic not found: {topic}')
+                log.error(f"{log_name} Topic not found: {topic}")
 
         if valid_topics:
-            required_dataset_values['groups'] = valid_topics
+            required_dataset_values["groups"] = valid_topics
 
     resources = []
 
-    required_dataset_values['rw_id'] = resource['dataset_id']
+    required_dataset_values["rw_id"] = resource["dataset_id"]
 
-    if application not in ['aqueduct', 'aqueduct-water-risk']:
+    if application not in ["aqueduct", "aqueduct-water-risk"]:
         for layer in layers:
             resource_dict = {}
-            layer_dict = layer.get('attributes', {})
-            layer_id = layer.get('id')
-            resource_dict['rw_id'] = layer_id
-            resource_dict['url'] = (
+            layer_dict = layer.get("attributes", {})
+            layer_id = layer.get("id")
+            resource_dict["rw_id"] = layer_id
+            resource_dict["url"] = (
                 f'https://api.resourcewatch.org/v1/dataset/{resource["dataset_id"]}/layer/{layer_id}'
             )
-            resource_dict['type'] = 'layer-raw'
-            resource_dict['url_type'] = 'layer-raw'
-            resource_dict['name'] = layer_dict.get('name', '')
-            resource_dict['format'] = 'Layer'
+            resource_dict["type"] = "layer-raw"
+            resource_dict["url_type"] = "layer-raw"
+            resource_dict["name"] = layer_dict.get("name", "")
+            resource_dict["format"] = "Layer"
 
             resources.append(resource_dict)
 
         if resources:
-            dataset_dict['resources'] = resources
+            dataset_dict["resources"] = resources
 
     if whitelist:
         dataset_dict = {
@@ -774,7 +811,7 @@ def prepare_dataset(
     dataset_dict = {**required_dataset_values, **dataset_dict}
 
     log.info(
-        f'{log_name} Finished preparing dataset: \n{json.dumps(dataset_dict, indent=2)}'
+        f"{log_name} Finished preparing dataset: \n{json.dumps(dataset_dict, indent=2)}"
     )
 
     return dataset_dict


### PR DESCRIPTION
Improves the migration existing package retrieval so that when a package isn't found by name, it also does a package_search with the rw_id and application (will be distinct and will not change—name/slug could potentially change at some point).

This also handles moving the extras to migration_extras in a better way. Before, it was checking for matching values, but this missed some like metadata updated, etc.