### PR TITLE
[Migration] Always migrate TIFs; Add GFW metadata

### DIFF
--- a/ckan-backend-dev/src/ckanext-wri/README.md
+++ b/ckan-backend-dev/src/ckanext-wri/README.md
@@ -235,8 +235,10 @@ Migrates an RW dataset/metadata to CKAN. It maps all supported RW fields to CKAN
 **Parameters:**
 - **id** (string) – The RW UUID of the dataset to migrate (required—unless `gfw_dataset` is provided). Example: `c0b5f4b1-4f3b-4f1e-8f1e-3f4b1f3b4f1e`.
 - **application** (string) – The RW application of the dataset to migrate (required). Example: `rw`.
-- **gfw_dataset** (string) – The GFW dataset to migrate (optional—if this dataset also has metadata in the RW API, you should also include `id`). Example: `gfw_forest_data`.
-- **gfw_version** (string) – The version of the GFW dataset to migrate (optional—will default to the latest if a specific version isn't provided). Example: `v2020.01.01`.
+- **dataset_slug** (string) – The desired slug of the dataset to migrate (optional). If you use this option, you will need to include this parameter each time you call `migrate_dataset` for this dataset. This value will override the `slug` value from the RW/GFW APIs. Example: `my-dataset`.
+- **dataset_title** (string) – The desired title of the dataset to migrate (optional). If you use this option, you will need to include this parameter each time you call `migrate_dataset` for this dataset. This value will override the `name` value from the RW API or the `title` value from the GFW API. Example: `My Dataset`.
+- **gfw_dataset** (string) – The GFW dataset to migrate (optional). If this dataset also has metadata in the RW API, you should also include `id`. Example: `gfw_forest_data`.
+- **gfw_version** (string) – The version of the GFW dataset to migrate (optional). Will default to the latest if a specific version isn't provided. Example: `v2020.01.01`.
 - **team** (string) – The `name` (`slug`) of the Team to associate the dataset with (optional). Example: `land-carbon-lab`.
 - **topics** (string) – A comma-separated list of Topic `slug`s to associate the dataset with (optional). Example: `atmosphere,biodiversity`.
 - **geographic_coverage** (string) – The geographic coverage of the dataset (optional). Example: `Global`.
@@ -433,7 +435,7 @@ You'll need this ID: `"id": "7cd8a09e-1834-4ab5-8b72-bd638e9392ae"` (`result.id`
 
 Add a custom file to the `migration/files` directory and commit it to the repo. Once deployed, you can use the `file_name` parameter to specify it. The file should be a CSV with the following columns:
 
-- `dataset_id` (required—unless `gfw_dataset` is provided)
+- `dataset_id` (required—unless `gfw_dataset` is provided—this is the same as the `id` parameter for `migrate_dataset`)
 - `application` (required)
 - `team` (optional)
 - `topics` (optional)
@@ -441,20 +443,23 @@ Add a custom file to the `migration/files` directory and commit it to the repo. 
 - `maintainer` (optional)
 - `maintainer_email` (optional)
 - `layer_ids` (optional)
+- `layer_names` (optional)
 - `gfw_dataset` (optional)
 - `gfw_version` (optional)
+- `dataset_title` (optional)
+- `dataset_slug` (optional)
 
 Example:
 
 ```csv
-dataset_id,gfw_dataset,application,team,topics,geographic_coverage,maintainer,maintainer_email,layer_ids
-d491f094-ad6e-4015-b248-1d1cd83667fa,,aqueduct-water-risk,aqueduct,"freshwater,surface-water-bodies",Global,John Doe,john.doe@example.com,,
-b318381e-485d-46c9-8958-c9a9d75d7e91,,aqueduct-water-risk,aqueduct,"freshwater,water-risks",Global,John Doe,john.doe@example.com,,
-faf79d2c-5e54-4591-9d70-4bd1029c18e6,,crt,agriadapt,atmosphere,Global,Jane Doe,jane.doe@example.com,,
-,gfw_forest_flux_forest_age_category,gfw,global-forest-watch,"land,ghg-emissions,forest",,Jane Doe,jane.doe@example.com,,
-,gfw_forest_flux_removal_forest_type,gfw,global-forest-watch,"land,ghg-emissions,forest",,John Doe,john.doe@example.com,,
-47a8e6cc-ea40-44a8-b1fc-6cf4fcc7d868,nasa_viirs_fire_alerts,gfw,global-forest-watch,"land,natural-hazards,forest",Global,,,2462cceb-41de-4bd2-8251-a6f75fe4e3d5
-c92b6411-f0e5-4606-bbd9-138e40e50eb8,,gfw,global-forest-watch,"land,forest",,Jeff Guy,jeff.guy@example.com,"0cba3c4f-2d3b-4fb1-8c93-c951dc1da84b,2351399c-ef2c-48da-9485-20698190acb0"
+dataset_id,gfw_dataset,application,team,topics,geographic_coverage,maintainer,maintainer_email,layer_ids,dataset_title,dataset_slug
+d491f094-ad6e-4015-b248-1d1cd83667fa,,aqueduct-water-risk,aqueduct,"freshwater,surface-water-bodies",Global,John Doe,john.doe@example.com,,An Aqueduct Dataset,an-aqueduct-dataset
+b318381e-485d-46c9-8958-c9a9d75d7e91,,aqueduct-water-risk,aqueduct,"freshwater,water-risks",Global,John Doe,john.doe@example.com,,Another Aqueduct Dataset,another-aqueduct-dataset
+faf79d2c-5e54-4591-9d70-4bd1029c18e6,,crt,agriadapt,atmosphere,Global,Jane Doe,jane.doe@example.com,,,
+,gfw_forest_flux_forest_age_category,gfw,global-forest-watch,"land,ghg-emissions,forest",,Jane Doe,jane.doe@example.com,,,
+,gfw_forest_flux_removal_forest_type,gfw,global-forest-watch,"land,ghg-emissions,forest",,John Doe,john.doe@example.com,,Another Title Example,
+47a8e6cc-ea40-44a8-b1fc-6cf4fcc7d868,nasa_viirs_fire_alerts,gfw,global-forest-watch,"land,natural-hazards,forest",Global,,,2462cceb-41de-4bd2-8251-a6f75fe4e3d5,,another-slug-example
+c92b6411-f0e5-4606-bbd9-138e40e50eb8,,gfw,global-forest-watch,"land,forest",,Jeff Guy,jeff.guy@example.com,"0cba3c4f-2d3b-4fb1-8c93-c951dc1da84b,2351399c-ef2c-48da-9485-20698190acb0",,
 ```
 
 #### POST /api/3/action/migration_status

--- a/ckan-backend-dev/src/ckanext-wri/ckanext/wri/logic/action/create.py
+++ b/ckan-backend-dev/src/ckanext-wri/ckanext/wri/logic/action/create.py
@@ -101,6 +101,8 @@ MIGRATE_DATASET_PARAMS = [
     "geographic_coverage",
     "whitelist",
     "blacklist",
+    "dataset_slug",
+    "dataset_title",
 ]
 
 

--- a/migration/tasks/migration_task.py
+++ b/migration/tasks/migration_task.py
@@ -811,7 +811,7 @@ def check_reponse_status(response):
 
     if response.status_code != 200:
         log.error(f"Error: {response.status_code} - {response.text}")
-        return False
+        raise Exception(f"Error: {response.status_code} - {response.text}")
     return True
 
 
@@ -850,7 +850,6 @@ def prepare_dataset(data_dict, original_data_dict, gfw_only=False):
 
     resource = data_dict.get("dataset", {})
     dataset = data_dict.get("metadata", {})
-    log.error(f"METADATA: {json.dumps(dataset, indent=2)}")
 
     if dataset:
         dataset = {**dataset, **dataset.get("info", {})}


### PR DESCRIPTION
## Changes

- GFW dataset migrations now include all TIFs from the GFW API, even when `layer_ids` are provided. Previously, if `layer_ids` was passed in, only the layer(s) specified would be added as a resource and GFW resources were ignored. Now, you should end up with both (GFW TIFs are always migrated, regardless of params used).
- Added `dataset_title`: Allows you to override the title that's pulled from the GFW/RW APIs (this param must be used every time a migration is run for this dataset, otherwise, the GFW/RW values will be used).
- Added `dataset_slug`: Allows you to override the slug/name that's pulled from the GFW/RW APIs (this param must be used every time a migration is run for this dataset, otherwise, the GFW/RW values will be used).
- GFW migrations will pull metadata from the GFW API instead of RW. If no value is found in GFW, RW is attempted. Previously, GFW didn't have metadata in these datasets, but they do now.