### PR TITLE
Add local nginx

### DIFF
--- a/ckan-backend-dev/.env.example
+++ b/ckan-backend-dev/.env.example
@@ -132,8 +132,8 @@ CKAN__CORS__ORIGIN_ALLOW_ALL = True
 # Frontend Creds
 NEXTAUTH_SECRET=secret
 NEXTAUTH_URL=http://frontend:3000
-CKAN_URL=http://ckan-dev:5000/private-admin/en
-NEXT_PUBLIC_CKAN_URL=http://ckan-dev:5000/private-admin/en
+CKAN_URL=http://ckan-dev:3001/private-admin/en
+NEXT_PUBLIC_CKAN_URL=http://ckan-dev:3001/private-admin/en
 NEXT_PUBLIC_NEXTAUTH_URL=http://frontend:3000
 NEXT_PUBLIC_GTM_ID=GTM-XXXXXX
 NEXT_PUBLIC_HOTJAR_ID=xxxxxxx

--- a/ckan-backend-dev/ckan/setup/nginx.conf
+++ b/ckan-backend-dev/ckan/setup/nginx.conf
@@ -9,6 +9,14 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    location /api/action {
+        proxy_pass http://ckan-dev:5000/api/3/action;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location / {
         proxy_pass http://host.docker.internal:3000/;
         proxy_set_header Host $host;

--- a/ckan-backend-dev/ckan/setup/nginx.conf
+++ b/ckan-backend-dev/ckan/setup/nginx.conf
@@ -1,0 +1,19 @@
+server {
+    listen 3001;
+
+    location /private-admin/ {
+        proxy_pass http://ckan-dev:5000/private-admin/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location / {
+        proxy_pass http://host.docker.internal:3000/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/ckan-backend-dev/docker-compose.dev.yml
+++ b/ckan-backend-dev/docker-compose.dev.yml
@@ -179,3 +179,16 @@ services:
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "-qO", "/dev/null", "http://localhost:8025/"]
+
+  nginx:
+    image: nginx:latest
+    container_name: nginx-redirect
+    ports:
+      - "3001:3001"
+    volumes:
+      - ./ckan/setup/nginx.conf:/etc/nginx/conf.d/default.conf
+    depends_on:
+      - ckan-dev
+    restart: unless-stopped
+    extra_hosts:
+      - "host.docker.internal:host-gateway"


### PR DESCRIPTION
Adds NGINX to the dev environment for a unified local domain where both the frontend and backend are accessible (`http://localhost:3001` and `http://localhost:3001/private-admin/*`).