### PR TITLE
Add support for multiple applications as groups

### DIFF
--- a/ckan-backend-dev/.env.example
+++ b/ckan-backend-dev/.env.example
@@ -102,7 +102,7 @@ CKANEXT__S3FILESTORE__HOST_NAME=http://minio:9000
 # scheming
 CKAN___SCHEMING__DATASET_SCHEMAS=ckanext.wri.schema:ckan_dataset.yaml
 CKAN___SCHEMING__ORGANIZATION_SCHEMAS=ckanext.scheming:custom_org_with_address.json
-CKAN___SCHEMING__GROUP_SCHEMAS=ckanext.scheming:custom_group_with_status.json
+CKAN___SCHEMING__GROUP_SCHEMAS=ckanext.wri.schema:wri_application.json
 CKAN___SCHEMING__PRESETS=ckanext.wri.schema:presets.json
 
 # auth

--- a/ckan-backend-dev/src/ckanext-wri/ckanext/wri/logic/action/create.py
+++ b/ckan-backend-dev/src/ckanext-wri/ckanext/wri/logic/action/create.py
@@ -221,6 +221,7 @@ def notification_create(
 
 def pending_dataset_create(context: Context, data_dict: DataDict):
     """Create a Pending Dataset"""
+    context["for_approval"] = True
     package_id = data_dict.get("package_id")
     package_data = data_dict.get("package_data")
 
@@ -408,6 +409,8 @@ def package_create(context: Context, data_dict: DataDict):
     data_dict["is_pending"] = True
     data_dict["is_approved"] = False
     data_dict["approval_status"] = "pending"
+    context["for_create"] = True
+    context["for_approval"] = True
 
     data_dict = stringify_actor_objects(data_dict)
 
@@ -566,6 +569,7 @@ def old_package_create(context: Context, data_dict: DataDict) -> ActionResult.Pa
     """
     model = context["model"]
     user = context["user"]
+    context["for_create"] = True
 
     # Override for authors/maintainers validation/formatting
     data_dict = stringify_actor_objects(data_dict)

--- a/ckan-backend-dev/src/ckanext-wri/ckanext/wri/logic/action/get.py
+++ b/ckan-backend-dev/src/ckanext-wri/ckanext/wri/logic/action/get.py
@@ -1342,14 +1342,13 @@ def _add_group_types(context: Context, data_dict: DataDict):
                     "homepage_url": group_dict.get("homepage_url"),
                 }
                 group.update(group_dict_updates)
-                package_applications.append(group["name"])
+                package_applications.append(group)
             else:
                 group.update({"type": group_type})
-
-            updated_package_groups.append(group)
+                updated_package_groups.append(group)
 
         data_dict["groups"] = updated_package_groups
-        data_dict["application"] = package_applications if package_applications else []
+        data_dict["applications"] = package_applications if package_applications else []
     except Exception as e:
         log.error(f"Error adding group types: {e}")
 

--- a/ckan-backend-dev/src/ckanext-wri/ckanext/wri/logic/action/get.py
+++ b/ckan-backend-dev/src/ckanext-wri/ckanext/wri/logic/action/get.py
@@ -8,6 +8,7 @@ import json
 from typing import Any, cast
 import re
 from itertools import zip_longest
+import socket
 
 from ckan.common import config, asbool
 from ckan.model import Package
@@ -390,6 +391,14 @@ def package_search(context: Context, data_dict: DataDict) -> ActionResult.Packag
 
         count = query.count
         facets = query.facets
+
+    results_with_group_types = []
+
+    for result in results:
+        result_dict = _add_group_types(context, result)
+        results_with_group_types.append(result_dict)
+
+    results = results_with_group_types
 
     search_results: dict[str, Any] = {
         "count": count,
@@ -1202,3 +1211,146 @@ def resource_search(context: Context, data_dict: DataDict):
 
 # TODO:  customize package_show to include spatial_geom
 # conditionally (optimization of the data file geo indexing)
+
+
+@logic.side_effect_free
+def package_show(context: Context, data_dict: DataDict) -> ActionResult.PackageShow:
+    """Return the metadata of a dataset (package) and its resources.
+
+    :param id: the id or name of the dataset
+    :type id: string
+    :param use_default_schema: use default package schema instead of
+        a custom schema defined with an IDatasetForm plugin (default: ``False``)
+    :type use_default_schema: bool
+    :param include_tracking: add tracking information to dataset and
+        resources (default: ``False``)
+    :type include_tracking: bool
+    :param include_plugin_data: Include the internal plugin data object
+        (sysadmin only, optional, default:``False``)
+    :type: include_plugin_data: bool
+    :rtype: dictionary
+
+    """
+    model = context["model"]
+    user_obj = context.get("auth_user_obj")
+    context["session"] = model.Session
+    name_or_id = data_dict.get("id") or _get_or_bust(data_dict, "name_or_id")
+
+    include_plugin_data = asbool(data_dict.get("include_plugin_data", False))
+    if user_obj and user_obj.is_authenticated:
+        include_plugin_data = user_obj.sysadmin and include_plugin_data
+
+        if include_plugin_data:
+            context["use_cache"] = False
+
+    pkg = model.Package.get(name_or_id, for_update=context.get("for_update", False))
+
+    if pkg is None:
+        raise NotFound
+
+    context["package"] = pkg
+    _check_access("package_show", context, data_dict)
+
+    if data_dict.get("use_default_schema", False):
+        context["schema"] = ckan.logic.schema.default_show_package_schema()
+
+    include_tracking = asbool(data_dict.get("include_tracking", False))
+
+    package_dict = None
+    use_cache = context.get("use_cache", True)
+    package_dict_validated = False
+
+    if use_cache:
+        try:
+            search_result = search.show(name_or_id)
+        except (search.SearchError, socket.error):
+            pass
+        else:
+            use_validated_cache = "schema" not in context
+            if use_validated_cache and "validated_data_dict" in search_result:
+                package_json = search_result["validated_data_dict"]
+                package_dict = json.loads(package_json)
+                package_dict_validated = True
+            else:
+                package_dict = json.loads(search_result["data_dict"])
+                package_dict_validated = False
+            metadata_modified = pkg.metadata_modified.isoformat()
+            search_metadata_modified = search_result["metadata_modified"]
+            # solr stores less precise datetime,
+            # truncate to 22 charactors to get good enough match
+            if metadata_modified[:22] != search_metadata_modified[:22]:
+                package_dict = None
+
+    if not package_dict:
+        package_dict = model_dictize.package_dictize(pkg, context, include_plugin_data)
+        package_dict_validated = False
+
+    if include_tracking:
+        # page-view tracking summary data
+        package_dict["tracking_summary"] = model.TrackingSummary.get_for_package(
+            package_dict["id"]
+        )
+
+        for resource_dict in package_dict["resources"]:
+            summary = model.TrackingSummary.get_for_resource(resource_dict["url"])
+            resource_dict["tracking_summary"] = summary
+
+    if context.get("for_view"):
+        for item in plugins.PluginImplementations(plugins.IPackageController):
+            package_dict = item.before_dataset_view(package_dict)
+
+    for item in plugins.PluginImplementations(plugins.IPackageController):
+        item.read(pkg)
+
+    for item in plugins.PluginImplementations(plugins.IResourceController):
+        for resource_dict in package_dict["resources"]:
+            item.before_resource_show(resource_dict)
+
+    if not package_dict_validated:
+        package_plugin = lib_plugins.lookup_package_plugin(package_dict["type"])
+        schema = context.get("schema") or package_plugin.show_package_schema()
+
+        if bool(schema) and context.get("validate", True):
+            package_dict, _errors = lib_plugins.plugin_validate(
+                package_plugin, context, package_dict, schema, "package_show"
+            )
+
+    for item in plugins.PluginImplementations(plugins.IPackageController):
+        item.after_dataset_show(context, package_dict)
+
+    package_dict = _add_group_types(context, package_dict)
+
+    return package_dict
+
+
+def _add_group_types(context: Context, data_dict: DataDict):
+    try:
+        package_groups = data_dict.get("groups", [])
+        updated_package_groups = []
+        package_applications = []
+
+        for group in package_groups:
+            group_dict = get_action("group_show")(context, {"id": group["id"]})
+            group_type = group_dict.get("type", "group")
+
+            if group_type == "application":
+                group_dict_updates = {
+                    "type": group_type,
+                    "contact_url": group_dict.get("contact_url"),
+                    "image_url": group_dict.get("image_url"),
+                    "help_url": group_dict.get("help_url"),
+                    "homepage_url": group_dict.get("homepage_url"),
+                }
+                group.update(group_dict_updates)
+                package_applications.append(group["name"])
+            else:
+                group.update({"type": group_type})
+
+            updated_package_groups.append(group)
+
+        data_dict["groups"] = updated_package_groups
+        data_dict["application"] = package_applications if package_applications else []
+    except Exception as e:
+        log.error(f"Error adding group types: {e}")
+
+    return data_dict

--- a/ckan-backend-dev/src/ckanext-wri/ckanext/wri/logic/action/get.py
+++ b/ckan-backend-dev/src/ckanext-wri/ckanext/wri/logic/action/get.py
@@ -581,6 +581,7 @@ def pending_diff_show(context: Context, data_dict: DataDict):
     try:
         pending_dataset = PendingDatasets.get(package_id=package_id)
         if pending_dataset is not None:
+            context["for_approval"] = True
             pending_dataset = pending_dataset.get("package_data")
             existing_dataset = get_action("package_show")(context, {"id": package_id})
             dataset_diff = _diff(existing_dataset, pending_dataset)
@@ -1213,6 +1214,8 @@ def resource_search(context: Context, data_dict: DataDict):
 # conditionally (optimization of the data file geo indexing)
 
 
+# IMPORTANT: This is almost a copy of the original package_show, but it calls the _add_group_types
+# function so that `applications` and `groups` are separated in the response.
 @logic.side_effect_free
 def package_show(context: Context, data_dict: DataDict) -> ActionResult.PackageShow:
     """Return the metadata of a dataset (package) and its resources.
@@ -1231,6 +1234,11 @@ def package_show(context: Context, data_dict: DataDict) -> ActionResult.PackageS
     :rtype: dictionary
 
     """
+    for_view = context.get("for_view", False)
+
+    if not for_view:
+        context["use_cache"] = False
+
     model = context["model"]
     user_obj = context.get("auth_user_obj")
     context["session"] = model.Session
@@ -1324,6 +1332,13 @@ def package_show(context: Context, data_dict: DataDict) -> ActionResult.PackageS
 
 
 def _add_group_types(context: Context, data_dict: DataDict):
+    for_view = context.get("for_view", False)
+    for_approval = context.get("for_approval", False)
+    for_update = context.get("for_update", False)
+    for_create = context.get("for_create", False)
+
+    if any([for_view, for_approval, for_update, for_create]):
+        return data_dict
     try:
         package_groups = data_dict.get("groups", [])
         updated_package_groups = []
@@ -1333,15 +1348,25 @@ def _add_group_types(context: Context, data_dict: DataDict):
             group_dict = get_action("group_show")(context, {"id": group["id"]})
             group_type = group_dict.get("type", "group")
 
+            new_group_dict = {
+                "contact_url": group_dict.get("contact_url"),
+                "url": group_dict.get("url"),
+                "help_url": group_dict.get("help_url"),
+                "homepage_url": group_dict.get("homepage_url"),
+            }
+
             if group_type == "application":
                 group_dict_updates = {
-                    "type": group_type,
-                    "contact_url": group_dict.get("contact_url"),
-                    "image_url": group_dict.get("image_url"),
-                    "help_url": group_dict.get("help_url"),
-                    "homepage_url": group_dict.get("homepage_url"),
+                    "type": group_type
                 }
                 group.update(group_dict_updates)
+
+                for key, value in new_group_dict.items():
+                    if value:
+                        group[key] = value
+                    else:
+                        group.pop(key, None)
+
                 package_applications.append(group)
             else:
                 group.update({"type": group_type})

--- a/ckan-backend-dev/src/ckanext-wri/ckanext/wri/logic/action/update.py
+++ b/ckan-backend-dev/src/ckanext-wri/ckanext/wri/logic/action/update.py
@@ -157,6 +157,7 @@ def notification_bulk_update(
 
 def pending_dataset_update(context: Context, data_dict: DataDict):
     """Update a Pending Dataset"""
+    context["for_approval"] = True
     package_id = data_dict.get("package_id")
     package_data = data_dict.get("package_data")
 
@@ -190,6 +191,7 @@ def issue_delete(context: Context, data_dict: DataDict):
 
 
 def package_patch(context: Context, data_dict: DataDict):
+    context["for_update"] = True
     dataset_id = data_dict.get("id")
     try:
         pending_dataset_dict = tk.get_action("pending_dataset_show")(
@@ -318,6 +320,7 @@ def old_package_update(context: Context, data_dict: DataDict) -> ActionResult.Pa
     :rtype: dictionary
 
     """
+    context["for_update"] = True
     model = context["model"]
     name_or_id = data_dict.get("id") or data_dict.get("name")
     if name_or_id is None:
@@ -492,6 +495,7 @@ def old_package_patch(context: Context, data_dict: DataDict) -> ActionResult.Pac
 
 def approve_pending_dataset(context: Context, data_dict: DataDict):
     dataset_id = data_dict.get("dataset_id")
+    context["for_approval"] = True
     # Fetch Pending Dataset Information
     try:
         pending_dataset_dict = tk.get_action("pending_dataset_show")(
@@ -650,6 +654,7 @@ def approve_pending_dataset(context: Context, data_dict: DataDict):
 
 
 # IMPORTANT: This function includes an override/change for authors/maintainers (using old_package_update instead of package_update).
+# It also includes an override/change for multiple application support (adds "for_update": True to the context).
 # This is not a 1:1 match with the original function, though all other logic is the same.
 def resource_update(
     context: Context, data_dict: DataDict
@@ -673,6 +678,7 @@ def resource_update(
     :rtype: string
 
     """
+    context["for_update"] = True
     model = context["model"]
     id: str = _get_or_bust(data_dict, "id")
 
@@ -736,3 +742,21 @@ def resource_update(
         plugin.after_resource_update(context, resource)
 
     return resource
+
+
+# IMPORTANT: This function includes an override/change to support multiple applications
+# We need to move the applications back to the groups field before calling the original package_update function
+def package_update(context: Context, data_dict: DataDict) -> ActionResult.PackageUpdate:
+    applications = data_dict.get("applications", [])
+
+    if applications:
+        if isinstance(applications, list) and all(
+            isinstance(app, dict) for app in applications
+        ):
+            data_dict["groups"] = data_dict.get("groups", []) + applications
+        else:
+            raise ValidationError(
+                {"applications": _("Applications must be a list of dictionaries")}
+            )
+
+    return old_package_update(context, data_dict)

--- a/ckan-backend-dev/src/ckanext-wri/ckanext/wri/logic/validators.py
+++ b/ckan-backend-dev/src/ckanext-wri/ckanext/wri/logic/validators.py
@@ -3,6 +3,9 @@ from typing import Any
 import pycountry
 import logging
 import json
+import re
+from urllib.parse import urlparse
+import string
 
 from ckan.types import Context
 from ckan.plugins.toolkit import ValidationError
@@ -230,3 +233,64 @@ def agents_json_object(value: Any, context: Context):
             _validate_agent(agent, context)
 
     return value
+
+
+def _url_validator(value: str) -> bool:
+    """Checks that the provided value is a valid URL"""
+    try:
+        pieces = urlparse(value)
+        if all([pieces.scheme, pieces.netloc]) and pieces.scheme in [
+            "http",
+            "https",
+        ]:
+            hostname, port = (
+                pieces.netloc.split(":")
+                if ":" in pieces.netloc
+                else (pieces.netloc, None)
+            )
+            if set(hostname) <= set(string.ascii_letters + string.digits + "-.") and (
+                port is None or port.isdigit()
+            ):
+                return True
+    except ValueError:
+        # url is invalid
+        pass
+    return False
+
+
+# pattern from https://html.spec.whatwg.org/#e-mail-state-(type=email)
+email_pattern = re.compile(
+    # additional pattern to reject malformed dots usage
+    r"^(?!\.)(?!.*\.$)(?!.*?\.\.)"
+    r"[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9]"
+    r"(?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9]"
+    r"(?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$"
+)
+
+
+def _email_validator(value: str) -> bool:
+    """Check that the value is a valid email address."""
+    if 'mailto:' in value:
+        value = value.split('mailto:')[1]
+        return bool(email_pattern.match(value))
+    else:
+        return False
+
+
+def url_or_email_validator(value: Any, context: Context):
+    """
+    Check that the value is a valid URL or email address.
+
+    e.g. "http://example.com" or "example.user@example.com"
+    """
+    if not value:
+        return
+
+    if not isinstance(value, str):
+        log.error("Value must be a string")
+        raise Invalid("Value must be a string")
+
+    if _email_validator(value) or _url_validator(value):
+        return value
+
+    raise Invalid(_("Invalid URL"))

--- a/ckan-backend-dev/src/ckanext-wri/ckanext/wri/plugin.py
+++ b/ckan-backend-dev/src/ckanext-wri/ckanext/wri/plugin.py
@@ -42,6 +42,7 @@ from ckanext.wri.logic.action.update import (
     resource_update,
     old_package_patch,
     old_package_update,
+    package_update
 )
 from ckanext.wri.model.resource_location import ResourceLocation
 from ckanext.wri.logic.action.get import (
@@ -163,7 +164,8 @@ class WriPlugin(plugins.SingletonPlugin):
         return {
             "iso_language_code": wri_validators.iso_language_code,
             "year_validator": wri_validators.year_validator,
-            "agents_json_object": wri_validators.agents_json_object
+            "agents_json_object": wri_validators.agents_json_object,
+            "url_or_email_validator": wri_validators.url_or_email_validator,
         }
 
     # IFacets
@@ -236,6 +238,7 @@ class WriPlugin(plugins.SingletonPlugin):
             "resource_create": resource_create,
             # "package_delete": package_delete,
             "package_show": package_show,
+            "package_update": package_update,
         }
 
     # IPermissionLabels
@@ -362,6 +365,13 @@ class WriPlugin(plugins.SingletonPlugin):
     def after_dataset_show(self, context, pkg_dict):
         authors = pkg_dict.get("authors")
         maintainers = pkg_dict.get("maintainers")
+        applications = pkg_dict.get("applications")
+
+        if applications:
+            context.pop("for_create", None)
+            context.pop("for_approval", None)
+            context.pop("for_update", None)
+            context.pop("for_view", None)
 
         if isinstance(authors, str):
             try:
@@ -386,6 +396,16 @@ class WriPlugin(plugins.SingletonPlugin):
         return self.before_dataset_search(search_params)
 
     def before_dataset_index(self, pkg_dict):
+        # Move the application group objects back to groups before indexing to avoid SOLR errors
+        applications = pkg_dict.get("applications")
+
+        if applications:
+            if isinstance(applications, list):
+                application_names = [app.get("name", app.get("id")) for app in applications if app.get("name", app.get("id"))]
+                pkg_dict["groups"] = pkg_dict.get("groups", []) + application_names
+
+        pkg_dict.pop("applications", None)
+
         if any(key in pkg_dict for key in ("authors", "maintainers")):
             pkg_dict = stringify_actor_objects(pkg_dict)
 

--- a/ckan-backend-dev/src/ckanext-wri/ckanext/wri/plugin.py
+++ b/ckan-backend-dev/src/ckanext-wri/ckanext/wri/plugin.py
@@ -15,7 +15,7 @@ from ckanext.wri.logic.action.datapusher_download_zip import (
 )
 import ckanext.wri.logic.validators as wri_validators
 from ckan import model, logic, authz
-from ckan.types import Action, AuthFunction, Context
+from ckan.types import Action, AuthFunction, Context, DataDict
 from ckan.lib.search import SearchError
 from ckanext.wri.logic.auth import auth as auth
 from ckanext.wri.logic.action.datapusher import (
@@ -62,6 +62,7 @@ from ckanext.wri.logic.action.get import (
     issue_search_wri,
     package_collaborator_list_wri,
     resource_search,
+    package_show,
 )
 
 from ckanext.wri.logic.action.delete import pending_dataset_delete
@@ -170,7 +171,6 @@ class WriPlugin(plugins.SingletonPlugin):
     def dataset_facets(self, facets_dict, package_type):
         facets_dict["language"] = toolkit._("Language")
         facets_dict["project"] = toolkit._("Project")
-        facets_dict["application"] = toolkit._("Application")
         facets_dict["temporal_coverage_start"] = toolkit._("Temporal Coverage Start")
         facets_dict["temporal_coverage_end"] = toolkit._("Temporal Coverage End")
         facets_dict["update_frequency"] = toolkit._("Update Frequency")
@@ -235,6 +235,7 @@ class WriPlugin(plugins.SingletonPlugin):
             "resource_update": resource_update,
             "resource_create": resource_create,
             # "package_delete": package_delete,
+            "package_show": package_show,
         }
 
     # IPermissionLabels

--- a/ckan-backend-dev/src/ckanext-wri/ckanext/wri/schema/ckan_dataset.yaml
+++ b/ckan-backend-dev/src/ckanext-wri/ckanext/wri/schema/ckan_dataset.yaml
@@ -84,10 +84,6 @@ dataset_fields:
   label: Project
   form_placeholder: eg. Project Name
 
-- field_name: application
-  label: Application
-  form_placeholder: eg. Application Name
-
 - field_name: technical_notes
   label: Technical Notes
   form_placeholder: eg. https://example.com/technical_notes.pdf

--- a/ckan-backend-dev/src/ckanext-wri/ckanext/wri/schema/wri_application.json
+++ b/ckan-backend-dev/src/ckanext-wri/ckanext/wri/schema/wri_application.json
@@ -44,13 +44,15 @@
       "label": "Contact URL",
       "form_placeholder": "http://example.com/my-organization/contact",
       "output_validators": "ignore_missing",
-      "validators": "ignore_missing url_validator"
+      "validators": "ignore_missing url_or_email_validator"
     },
     {
       "field_name": "image_url",
       "label": "Image/Icon",
       "preset": "organization_url_upload",
-      "form_placeholder": "http://example.com/my-organization/image.png"
+      "form_placeholder": "http://example.com/my-organization/image.png",
+      "output_validators": "ignore_missing",
+      "validators": "ignore_missing"
     }
   ]
 }

--- a/ckan-backend-dev/src/ckanext-wri/ckanext/wri/schema/wri_application.json
+++ b/ckan-backend-dev/src/ckanext-wri/ckanext/wri/schema/wri_application.json
@@ -1,0 +1,56 @@
+{
+  "scheming_version": 1,
+  "group_type": "application",
+  "about_url": "http://github.com/ckan/ckanext-scheming",
+  "fields": [
+    {
+      "field_name": "title",
+      "label": "Title",
+      "validators": "not_empty unicode_safe",
+      "form_snippet": "large_text.html",
+      "form_attrs": { "data-module": "slug-preview-target" },
+      "form_placeholder": "My Organization"
+    },
+    {
+      "field_name": "name",
+      "label": "URL",
+      "validators": "not_empty unicode_safe name_validator group_name_validator",
+      "form_snippet": "slug.html",
+      "form_placeholder": "my-organization"
+    },
+    {
+      "field_name": "description",
+      "label": "Description",
+      "form_snippet": "markdown.html",
+      "form_placeholder": "A little information about my organization...",
+      "validators": "not_empty"
+    },
+    {
+      "field_name": "homepage_url",
+      "label": "Home Page URL",
+      "form_placeholder": "http://example.com/my-organization",
+      "output_validators": "ignore_missing",
+      "validators": "not_empty url_validator"
+    },
+    {
+      "field_name": "help_url",
+      "label": "Help URL",
+      "form_placeholder": "http://example.com/my-organization/help",
+      "output_validators": "ignore_missing",
+      "validators": "ignore_missing url_validator"
+    },
+    {
+      "field_name": "contact_url",
+      "label": "Contact URL",
+      "form_placeholder": "http://example.com/my-organization/contact",
+      "output_validators": "ignore_missing",
+      "validators": "ignore_missing url_validator"
+    },
+    {
+      "field_name": "image_url",
+      "label": "Image/Icon",
+      "preset": "organization_url_upload",
+      "form_placeholder": "http://example.com/my-organization/image.png"
+    }
+  ]
+}

--- a/ckan-backend-dev/src/ckanext-wri/ckanext/wri/templates/header.html
+++ b/ckan-backend-dev/src/ckanext-wri/ckanext/wri/templates/header.html
@@ -1,0 +1,17 @@
+{% ckan_extends %}
+
+{% block header_site_navigation_tabs %}
+  {% set org_type = h.default_group_type('organization') %}
+  {% set group_type = h.default_group_type('group') %}
+
+  {{ h.build_nav_main(
+    (dataset_type ~ '.search', h.humanize_entity_type('package', dataset_type, 'main nav') or _('Datasets'), ["dataset", "resource"]),
+    (org_type ~ '.index',
+  h.humanize_entity_type('organization', org_type, 'main nav') or _('Organizations'), ['organization']),
+    (group_type ~ '.index',
+  h.humanize_entity_type('group', group_type, 'main nav') or _('Groups'), ['group']),
+    ('application.index',
+  h.humanize_entity_type('group', 'application', 'main nav') or _('Applications'), ['application']),
+    ('home.about', _('About'))
+  ) }}
+{% endblock %}

--- a/ckan-backend-dev/src/ckanext-wri/ckanext/wri/templates/package/group_list.html
+++ b/ckan-backend-dev/src/ckanext-wri/ckanext/wri/templates/package/group_list.html
@@ -1,0 +1,31 @@
+{% extends "package/read_base.html" %}
+{% import 'macros/form.html' as form %}
+
+{% set default_group_type = h.default_group_type('group') %}
+
+{% block primary_content_inner %}
+fdhjgkhfdgh
+  <h2 class="hide-heading">{{ h.humanize_entity_type('group', default_group_type, 'page title') or _('Groups') }}</h2>
+
+  {% if group_dropdown %}
+    <form class="add-to-group" method="post">
+      {{ h.csrf_input() }}
+      <select id="field-add_group" name="group_added" data-module="autocomplete">
+        {% for option in group_dropdown %}
+          <option value="{{ option[0] }}"> {{ option[1] }}</option>
+        {% endfor %}
+      </select>
+      <button type="submit" class="btn btn-primary" title="{{ _('Associate this group with this dataset') }}">{{ _('Add to group') }}</button>
+    </form>
+  {% endif %}
+
+  {% if pkg_dict.groups %}
+    <form method="post">
+      {{ h.csrf_input() }}
+      {% snippet 'group/snippets/group_list.html', groups=pkg_dict.groups %}
+    </form>
+  {% else %}
+    <p class="empty">{{ h.humanize_entity_type('group', default_group_type, 'no associated label') or _('There are no groups associated with this dataset') }}</p>
+  {% endif %}
+
+{% endblock %}

--- a/ckan-backend-dev/src/ckanext-wri/ckanext/wri/tests/test_application_groups.py
+++ b/ckan-backend-dev/src/ckanext-wri/ckanext/wri/tests/test_application_groups.py
@@ -1,0 +1,225 @@
+import pytest
+
+import ckan.tests.factories as factories
+from ckan.logic import get_action
+from ckan import model
+import unittest.mock as mock
+from ckan.logic import ValidationError
+
+
+# @mock.patch("ckan.plugins.toolkit.mail_user")
+# @pytest.mark.usefixtures("with_plugins", "test_request_context")
+# def test_application_group_create_all_fields(mail_user):
+#    userobj = factories.Sysadmin()
+#    session = model.Session
+#    context = {
+#        "model": model, "session": session,
+#        "user": userobj["name"], "ignore_auth": True,
+#        "user_obj": userobj
+#    }
+#    context["auth_user_obj"] = model.User.get(context["user"])
+#
+#    application_group = {
+#        "name": "test-application-group-schema",
+#        "title": "Test Application Group Schema",
+#        "description": "A description of the application group",
+#        "homepage_url": "http://example.com",
+#        "help_url": "http://example.com/help",
+#        "contact_url": "http://example.com/contact",
+#        "image_url": "http://example.com/image",
+#        "type": "application",
+#    }
+#
+#    try:
+#        get_action("group_purge")(
+#            context={"ignore_auth": True},
+#            data_dict={"id": application_group["name"]}
+#        )
+#    except Exception:
+#        pass
+#
+#    application_group = get_action("group_create")(context, application_group)
+#
+#    assert application_group["name"] == "test-application-group-schema"
+#    assert application_group["title"] == "Test Application Group Schema"
+#    assert application_group["description"] == "A description of the application group"
+#    assert application_group["homepage_url"] == "http://example.com"
+#    assert application_group["help_url"] == "http://example.com/help"
+#    assert application_group["contact_url"] == "http://example.com/contact"
+#    assert application_group["image_url"] == "http://example.com/image"
+#    assert application_group["type"] == "application"
+#
+#    get_action("group_purge")(
+#        context={"ignore_auth": True},
+#        data_dict={"id": application_group["name"]}
+#    )
+#
+#
+# @mock.patch("ckan.plugins.toolkit.mail_user")
+# @pytest.mark.usefixtures("with_plugins", "test_request_context")
+# def test_application_group_update_all_fields(mail_user):
+#    userobj = factories.Sysadmin()
+#    session = model.Session
+#    context = {
+#        "model": model, "session": session,
+#        "user": userobj["name"], "ignore_auth": True,
+#        "user_obj": userobj
+#    }
+#    context["auth_user_obj"] = model.User.get(context["user"])
+#
+#    application_group = {
+#        "name": "test-application-group-schema",
+#        "title": "Test Application Group Schema",
+#        "description": "A description of the application group",
+#        "homepage_url": "http://example.com",
+#        "help_url": "http://example.com/help",
+#        "contact_url": "http://example.com/contact",
+#        "image_url": "http://example.com/image",
+#        "type": "application",
+#    }
+#
+#    try:
+#        get_action("group_purge")(
+#            context={"ignore_auth": True},
+#            data_dict={"id": application_group["name"]}
+#        )
+#    except Exception:
+#        pass
+#
+#    application_group = get_action("group_create")(context, application_group)
+#
+#    application_group = get_action("group_update")(
+#        context, {
+#            "id": application_group["id"],
+#            "name": application_group["name"],
+#            "title": "New Title",
+#            "description": "New Description",
+#            "homepage_url": "http://new.example.com",
+#            "help_url": "http://new.example.com/help",
+#            "contact_url": "http://new.example.com/contact",
+#            "image_url": "http://new.example.com/image",
+#        }
+#    )
+#
+#    application_group = get_action("group_show")(context, {"id": application_group["id"]})
+#
+#    assert application_group["name"] == "test-application-group-schema"
+#    assert application_group["title"] == "New Title"
+#    assert application_group["description"] == "New Description"
+#    assert application_group["homepage_url"] == "http://new.example.com"
+#    assert application_group["help_url"] == "http://new.example.com/help"
+#    assert application_group["contact_url"] == "http://new.example.com/contact"
+#    assert application_group["image_url"] == "http://new.example.com/image"
+#    assert application_group["type"] == "application"
+#
+#    get_action("group_purge")(
+#        context={"ignore_auth": True},
+#        data_dict={"id": application_group["name"]}
+#    )
+
+
+@mock.patch("ckan.plugins.toolkit.mail_user")
+@pytest.mark.usefixtures("with_plugins", "test_request_context")
+def test_application_group_validators(mail_user):
+    userobj = factories.Sysadmin()
+    session = model.Session
+    context = {
+        "model": model, "session": session,
+        "user": userobj["name"], "ignore_auth": True,
+        "user_obj": userobj
+    }
+    context["auth_user_obj"] = model.User.get(context["user"])
+
+    url_fields = ["homepage_url", "help_url", "contact_url"]
+
+    application_group = {
+        "name": "test-application-group-schema",
+        "title": "Test Application Group Schema",
+        "description": "A description of the application group",
+        "homepage_url": "http://example.com",
+        "help_url": "http://example.com/help",
+        "contact_url": "http://example.com/contact",
+        "image_url": "http://example.com/image",
+        "type": "application",
+    }
+
+    for field in url_fields:
+        application_group[field] = "not a URL"
+
+        with pytest.raises(ValidationError):
+            get_action("group_create")(context, application_group)
+
+        application_group[field] = f"http://example.com/{field}"
+
+    application_group = get_action("group_create")(context, application_group)
+
+    assert application_group["name"] == "test-application-group-schema"
+    assert application_group["title"] == "Test Application Group Schema"
+    assert application_group["description"] == "A description of the application group"
+    assert application_group["homepage_url"] == "http://example.com/homepage_url"
+    assert application_group["help_url"] == "http://example.com/help_url"
+    assert application_group["contact_url"] == "http://example.com/contact_url"
+    assert application_group["image_url"] == "http://example.com/image"
+    assert application_group["type"] == "application"
+
+    get_action("group_purge")(
+        context={"ignore_auth": True},
+        data_dict={"id": application_group["name"]}
+    )
+
+
+@mock.patch("ckan.plugins.toolkit.mail_user")
+@pytest.mark.usefixtures("with_plugins", "test_request_context")
+def test_application_group_required_fields(mail_user):
+    userobj = factories.Sysadmin()
+    session = model.Session
+    context = {
+        "model": model, "session": session,
+        "user": userobj["name"], "ignore_auth": True,
+        "user_obj": userobj
+    }
+    context["auth_user_obj"] = model.User.get(context["user"])
+
+    required_fields = ["name", "title", "description", "homepage_url"]
+
+    valid_field_values = {
+        "name": "test-application-group-schema",
+        "title": "Test Application Group Schema",
+        "description": "A description of the application group",
+        "homepage_url": "http://example.com"
+    }
+
+    application_group = {
+        "name": "test-application-group-schema",
+        "title": "Test Application Group Schema",
+        "description": "A description of the application group",
+        "homepage_url": "http://example.com",
+        "help_url": "http://example.com/help",
+        "contact_url": "http://example.com/contact",
+        "image_url": "http://example.com/image",
+        "type": "application",
+    }
+
+    for field in required_fields:
+        del application_group[field]
+
+        with pytest.raises(ValidationError):
+            get_action("group_create")(context, application_group)
+
+        application_group[field] = valid_field_values[field]
+
+    application_group = get_action("group_create")(context, application_group)
+
+    assert application_group["name"] == "test-application-group-schema"
+    assert application_group["title"] == "Test Application Group Schema"
+    assert application_group["description"] == "A description of the application group"
+    assert application_group["homepage_url"] == "http://example.com"
+    assert application_group["help_url"] == "http://example.com/help"
+    assert application_group["contact_url"] == "http://example.com/contact"
+    assert application_group["image_url"] == "http://example.com/image"
+    assert application_group["type"] == "application"
+
+    get_action("group_purge")(
+        context={"ignore_auth": True},
+        data_dict={"id": application_group["name"]}
+    )

--- a/ckan-backend-dev/src/ckanext-wri/ckanext/wri/tests/test_application_groups.py
+++ b/ckan-backend-dev/src/ckanext-wri/ckanext/wri/tests/test_application_groups.py
@@ -7,115 +7,115 @@ import unittest.mock as mock
 from ckan.logic import ValidationError
 
 
-# @mock.patch("ckan.plugins.toolkit.mail_user")
-# @pytest.mark.usefixtures("with_plugins", "test_request_context")
-# def test_application_group_create_all_fields(mail_user):
-#    userobj = factories.Sysadmin()
-#    session = model.Session
-#    context = {
-#        "model": model, "session": session,
-#        "user": userobj["name"], "ignore_auth": True,
-#        "user_obj": userobj
-#    }
-#    context["auth_user_obj"] = model.User.get(context["user"])
-#
-#    application_group = {
-#        "name": "test-application-group-schema",
-#        "title": "Test Application Group Schema",
-#        "description": "A description of the application group",
-#        "homepage_url": "http://example.com",
-#        "help_url": "http://example.com/help",
-#        "contact_url": "http://example.com/contact",
-#        "image_url": "http://example.com/image",
-#        "type": "application",
-#    }
-#
-#    try:
-#        get_action("group_purge")(
-#            context={"ignore_auth": True},
-#            data_dict={"id": application_group["name"]}
-#        )
-#    except Exception:
-#        pass
-#
-#    application_group = get_action("group_create")(context, application_group)
-#
-#    assert application_group["name"] == "test-application-group-schema"
-#    assert application_group["title"] == "Test Application Group Schema"
-#    assert application_group["description"] == "A description of the application group"
-#    assert application_group["homepage_url"] == "http://example.com"
-#    assert application_group["help_url"] == "http://example.com/help"
-#    assert application_group["contact_url"] == "http://example.com/contact"
-#    assert application_group["image_url"] == "http://example.com/image"
-#    assert application_group["type"] == "application"
-#
-#    get_action("group_purge")(
-#        context={"ignore_auth": True},
-#        data_dict={"id": application_group["name"]}
-#    )
-#
-#
-# @mock.patch("ckan.plugins.toolkit.mail_user")
-# @pytest.mark.usefixtures("with_plugins", "test_request_context")
-# def test_application_group_update_all_fields(mail_user):
-#    userobj = factories.Sysadmin()
-#    session = model.Session
-#    context = {
-#        "model": model, "session": session,
-#        "user": userobj["name"], "ignore_auth": True,
-#        "user_obj": userobj
-#    }
-#    context["auth_user_obj"] = model.User.get(context["user"])
-#
-#    application_group = {
-#        "name": "test-application-group-schema",
-#        "title": "Test Application Group Schema",
-#        "description": "A description of the application group",
-#        "homepage_url": "http://example.com",
-#        "help_url": "http://example.com/help",
-#        "contact_url": "http://example.com/contact",
-#        "image_url": "http://example.com/image",
-#        "type": "application",
-#    }
-#
-#    try:
-#        get_action("group_purge")(
-#            context={"ignore_auth": True},
-#            data_dict={"id": application_group["name"]}
-#        )
-#    except Exception:
-#        pass
-#
-#    application_group = get_action("group_create")(context, application_group)
-#
-#    application_group = get_action("group_update")(
-#        context, {
-#            "id": application_group["id"],
-#            "name": application_group["name"],
-#            "title": "New Title",
-#            "description": "New Description",
-#            "homepage_url": "http://new.example.com",
-#            "help_url": "http://new.example.com/help",
-#            "contact_url": "http://new.example.com/contact",
-#            "image_url": "http://new.example.com/image",
-#        }
-#    )
-#
-#    application_group = get_action("group_show")(context, {"id": application_group["id"]})
-#
-#    assert application_group["name"] == "test-application-group-schema"
-#    assert application_group["title"] == "New Title"
-#    assert application_group["description"] == "New Description"
-#    assert application_group["homepage_url"] == "http://new.example.com"
-#    assert application_group["help_url"] == "http://new.example.com/help"
-#    assert application_group["contact_url"] == "http://new.example.com/contact"
-#    assert application_group["image_url"] == "http://new.example.com/image"
-#    assert application_group["type"] == "application"
-#
-#    get_action("group_purge")(
-#        context={"ignore_auth": True},
-#        data_dict={"id": application_group["name"]}
-#    )
+@mock.patch("ckan.plugins.toolkit.mail_user")
+@pytest.mark.usefixtures("with_plugins", "test_request_context")
+def test_application_group_create_all_fields(mail_user):
+   userobj = factories.Sysadmin()
+   session = model.Session
+   context = {
+       "model": model, "session": session,
+       "user": userobj["name"], "ignore_auth": True,
+       "user_obj": userobj
+   }
+   context["auth_user_obj"] = model.User.get(context["user"])
+
+   application_group = {
+       "name": "test-application-group-schema",
+       "title": "Test Application Group Schema",
+       "description": "A description of the application group",
+       "homepage_url": "http://example.com",
+       "help_url": "http://example.com/help",
+       "contact_url": "http://example.com/contact",
+       "image_url": "http://example.com/image",
+       "type": "application",
+   }
+
+   try:
+       get_action("group_purge")(
+           context={"ignore_auth": True},
+           data_dict={"id": application_group["name"]}
+       )
+   except Exception:
+       pass
+
+   application_group = get_action("group_create")(context, application_group)
+
+   assert application_group["name"] == "test-application-group-schema"
+   assert application_group["title"] == "Test Application Group Schema"
+   assert application_group["description"] == "A description of the application group"
+   assert application_group["homepage_url"] == "http://example.com"
+   assert application_group["help_url"] == "http://example.com/help"
+   assert application_group["contact_url"] == "http://example.com/contact"
+   assert application_group["image_url"] == "http://example.com/image"
+   assert application_group["type"] == "application"
+
+   get_action("group_purge")(
+       context={"ignore_auth": True},
+       data_dict={"id": application_group["name"]}
+   )
+
+
+@mock.patch("ckan.plugins.toolkit.mail_user")
+@pytest.mark.usefixtures("with_plugins", "test_request_context")
+def test_application_group_update_all_fields(mail_user):
+   userobj = factories.Sysadmin()
+   session = model.Session
+   context = {
+       "model": model, "session": session,
+       "user": userobj["name"], "ignore_auth": True,
+       "user_obj": userobj
+   }
+   context["auth_user_obj"] = model.User.get(context["user"])
+
+   application_group = {
+       "name": "test-application-group-schema",
+       "title": "Test Application Group Schema",
+       "description": "A description of the application group",
+       "homepage_url": "http://example.com",
+       "help_url": "http://example.com/help",
+       "contact_url": "http://example.com/contact",
+       "image_url": "http://example.com/image",
+       "type": "application",
+   }
+
+   try:
+       get_action("group_purge")(
+           context={"ignore_auth": True},
+           data_dict={"id": application_group["name"]}
+       )
+   except Exception:
+       pass
+
+   application_group = get_action("group_create")(context, application_group)
+
+   application_group = get_action("group_update")(
+       context, {
+           "id": application_group["id"],
+           "name": application_group["name"],
+           "title": "New Title",
+           "description": "New Description",
+           "homepage_url": "http://new.example.com",
+           "help_url": "http://new.example.com/help",
+           "contact_url": "http://new.example.com/contact",
+           "image_url": "http://new.example.com/image",
+       }
+   )
+
+   application_group = get_action("group_show")(context, {"id": application_group["id"]})
+
+   assert application_group["name"] == "test-application-group-schema"
+   assert application_group["title"] == "New Title"
+   assert application_group["description"] == "New Description"
+   assert application_group["homepage_url"] == "http://new.example.com"
+   assert application_group["help_url"] == "http://new.example.com/help"
+   assert application_group["contact_url"] == "http://new.example.com/contact"
+   assert application_group["image_url"] == "http://new.example.com/image"
+   assert application_group["type"] == "application"
+
+   get_action("group_purge")(
+       context={"ignore_auth": True},
+       data_dict={"id": application_group["name"]}
+   )
 
 
 @mock.patch("ckan.plugins.toolkit.mail_user")

--- a/ckan-backend-dev/src/ckanext-wri/ckanext/wri/tests/test_application_groups.py
+++ b/ckan-backend-dev/src/ckanext-wri/ckanext/wri/tests/test_application_groups.py
@@ -10,112 +10,118 @@ from ckan.logic import ValidationError
 @mock.patch("ckan.plugins.toolkit.mail_user")
 @pytest.mark.usefixtures("with_plugins", "test_request_context")
 def test_application_group_create_all_fields(mail_user):
-   userobj = factories.Sysadmin()
-   session = model.Session
-   context = {
-       "model": model, "session": session,
-       "user": userobj["name"], "ignore_auth": True,
-       "user_obj": userobj
-   }
-   context["auth_user_obj"] = model.User.get(context["user"])
+    userobj = factories.Sysadmin()
+    session = model.Session
+    context = {
+        "model": model,
+        "session": session,
+        "user": userobj["name"],
+        "ignore_auth": True,
+        "user_obj": userobj,
+    }
+    context["auth_user_obj"] = model.User.get(context["user"])
 
-   application_group = {
-       "name": "test-application-group-schema",
-       "title": "Test Application Group Schema",
-       "description": "A description of the application group",
-       "homepage_url": "http://example.com",
-       "help_url": "http://example.com/help",
-       "contact_url": "http://example.com/contact",
-       "image_url": "http://example.com/image",
-       "type": "application",
-   }
+    application_group = {
+        "name": "test-application-group-schema",
+        "title": "Test Application Group Schema",
+        "description": "A description of the application group",
+        "homepage_url": "http://example.com",
+        "help_url": "http://example.com/help",
+        "contact_url": "http://example.com/contact",
+        "image_url": "http://example.com/image",
+        "type": "application",
+    }
 
-   try:
-       get_action("group_purge")(
-           context={"ignore_auth": True},
-           data_dict={"id": application_group["name"]}
-       )
-   except Exception:
-       pass
+    try:
+        get_action("group_purge")(
+            context={"ignore_auth": True}, data_dict={"id": application_group["name"]}
+        )
+    except Exception:
+        pass
 
-   application_group = get_action("group_create")(context, application_group)
+    application_group = get_action("group_create")(context, application_group)
+    application_group = get_action("group_show")(
+        context, {"id": application_group["name"]}
+    )
 
-   assert application_group["name"] == "test-application-group-schema"
-   assert application_group["title"] == "Test Application Group Schema"
-   assert application_group["description"] == "A description of the application group"
-   assert application_group["homepage_url"] == "http://example.com"
-   assert application_group["help_url"] == "http://example.com/help"
-   assert application_group["contact_url"] == "http://example.com/contact"
-   assert application_group["image_url"] == "http://example.com/image"
-   assert application_group["type"] == "application"
+    assert application_group["name"] == "test-application-group-schema"
+    assert application_group["title"] == "Test Application Group Schema"
+    assert application_group["description"] == "A description of the application group"
+    assert application_group["homepage_url"] == "http://example.com"
+    assert application_group["help_url"] == "http://example.com/help"
+    assert application_group["contact_url"] == "http://example.com/contact"
+    assert application_group["image_url"] == "http://example.com/image"
+    assert application_group["type"] == "application"
 
-   get_action("group_purge")(
-       context={"ignore_auth": True},
-       data_dict={"id": application_group["name"]}
-   )
+    get_action("group_purge")(
+        context={"ignore_auth": True}, data_dict={"id": application_group["name"]}
+    )
 
 
 @mock.patch("ckan.plugins.toolkit.mail_user")
 @pytest.mark.usefixtures("with_plugins", "test_request_context")
 def test_application_group_update_all_fields(mail_user):
-   userobj = factories.Sysadmin()
-   session = model.Session
-   context = {
-       "model": model, "session": session,
-       "user": userobj["name"], "ignore_auth": True,
-       "user_obj": userobj
-   }
-   context["auth_user_obj"] = model.User.get(context["user"])
+    userobj = factories.Sysadmin()
+    session = model.Session
+    context = {
+        "model": model,
+        "session": session,
+        "user": userobj["name"],
+        "ignore_auth": True,
+        "user_obj": userobj,
+    }
+    context["auth_user_obj"] = model.User.get(context["user"])
 
-   application_group = {
-       "name": "test-application-group-schema",
-       "title": "Test Application Group Schema",
-       "description": "A description of the application group",
-       "homepage_url": "http://example.com",
-       "help_url": "http://example.com/help",
-       "contact_url": "http://example.com/contact",
-       "image_url": "http://example.com/image",
-       "type": "application",
-   }
+    application_group = {
+        "name": "test-application-group-schema",
+        "title": "Test Application Group Schema",
+        "description": "A description of the application group",
+        "homepage_url": "http://example.com",
+        "help_url": "http://example.com/help",
+        "contact_url": "http://example.com/contact",
+        "image_url": "http://example.com/image",
+        "type": "application",
+    }
 
-   try:
-       get_action("group_purge")(
-           context={"ignore_auth": True},
-           data_dict={"id": application_group["name"]}
-       )
-   except Exception:
-       pass
+    try:
+        get_action("group_purge")(
+            context={"ignore_auth": True}, data_dict={"id": application_group["name"]}
+        )
+    except Exception:
+        pass
 
-   application_group = get_action("group_create")(context, application_group)
+    application_group = get_action("group_create")(context, application_group)
 
-   application_group = get_action("group_update")(
-       context, {
-           "id": application_group["id"],
-           "name": application_group["name"],
-           "title": "New Title",
-           "description": "New Description",
-           "homepage_url": "http://new.example.com",
-           "help_url": "http://new.example.com/help",
-           "contact_url": "http://new.example.com/contact",
-           "image_url": "http://new.example.com/image",
-       }
-   )
+    application_group = get_action("group_update")(
+        context,
+        {
+            "id": application_group["id"],
+            "name": application_group["name"],
+            "title": "New Title",
+            "description": "New Description",
+            "homepage_url": "http://new.example.com",
+            "help_url": "http://new.example.com/help",
+            "contact_url": "http://new.example.com/contact",
+            "image_url": "http://new.example.com/image",
+        },
+    )
 
-   application_group = get_action("group_show")(context, {"id": application_group["id"]})
+    application_group = get_action("group_show")(
+        context, {"id": application_group["id"]}
+    )
 
-   assert application_group["name"] == "test-application-group-schema"
-   assert application_group["title"] == "New Title"
-   assert application_group["description"] == "New Description"
-   assert application_group["homepage_url"] == "http://new.example.com"
-   assert application_group["help_url"] == "http://new.example.com/help"
-   assert application_group["contact_url"] == "http://new.example.com/contact"
-   assert application_group["image_url"] == "http://new.example.com/image"
-   assert application_group["type"] == "application"
+    assert application_group["name"] == "test-application-group-schema"
+    assert application_group["title"] == "New Title"
+    assert application_group["description"] == "New Description"
+    assert application_group["homepage_url"] == "http://new.example.com"
+    assert application_group["help_url"] == "http://new.example.com/help"
+    assert application_group["contact_url"] == "http://new.example.com/contact"
+    assert application_group["image_url"] == "http://new.example.com/image"
+    assert application_group["type"] == "application"
 
-   get_action("group_purge")(
-       context={"ignore_auth": True},
-       data_dict={"id": application_group["name"]}
-   )
+    get_action("group_purge")(
+        context={"ignore_auth": True}, data_dict={"id": application_group["name"]}
+    )
 
 
 @mock.patch("ckan.plugins.toolkit.mail_user")
@@ -124,9 +130,11 @@ def test_application_group_validators(mail_user):
     userobj = factories.Sysadmin()
     session = model.Session
     context = {
-        "model": model, "session": session,
-        "user": userobj["name"], "ignore_auth": True,
-        "user_obj": userobj
+        "model": model,
+        "session": session,
+        "user": userobj["name"],
+        "ignore_auth": True,
+        "user_obj": userobj,
     }
     context["auth_user_obj"] = model.User.get(context["user"])
 
@@ -152,6 +160,9 @@ def test_application_group_validators(mail_user):
         application_group[field] = f"http://example.com/{field}"
 
     application_group = get_action("group_create")(context, application_group)
+    application_group = get_action("group_show")(
+        context, {"id": application_group["id"]}
+    )
 
     assert application_group["name"] == "test-application-group-schema"
     assert application_group["title"] == "Test Application Group Schema"
@@ -163,8 +174,7 @@ def test_application_group_validators(mail_user):
     assert application_group["type"] == "application"
 
     get_action("group_purge")(
-        context={"ignore_auth": True},
-        data_dict={"id": application_group["name"]}
+        context={"ignore_auth": True}, data_dict={"id": application_group["name"]}
     )
 
 
@@ -174,9 +184,11 @@ def test_application_group_required_fields(mail_user):
     userobj = factories.Sysadmin()
     session = model.Session
     context = {
-        "model": model, "session": session,
-        "user": userobj["name"], "ignore_auth": True,
-        "user_obj": userobj
+        "model": model,
+        "session": session,
+        "user": userobj["name"],
+        "ignore_auth": True,
+        "user_obj": userobj,
     }
     context["auth_user_obj"] = model.User.get(context["user"])
 
@@ -186,7 +198,7 @@ def test_application_group_required_fields(mail_user):
         "name": "test-application-group-schema",
         "title": "Test Application Group Schema",
         "description": "A description of the application group",
-        "homepage_url": "http://example.com"
+        "homepage_url": "http://example.com",
     }
 
     application_group = {
@@ -200,6 +212,13 @@ def test_application_group_required_fields(mail_user):
         "type": "application",
     }
 
+    try:
+        get_action("group_purge")(
+            context={"ignore_auth": True}, data_dict={"id": application_group["name"]}
+        )
+    except Exception:
+        pass
+
     for field in required_fields:
         del application_group[field]
 
@@ -209,6 +228,9 @@ def test_application_group_required_fields(mail_user):
         application_group[field] = valid_field_values[field]
 
     application_group = get_action("group_create")(context, application_group)
+    application_group = get_action("group_show")(
+        context, {"id": application_group["id"]}
+    )
 
     assert application_group["name"] == "test-application-group-schema"
     assert application_group["title"] == "Test Application Group Schema"
@@ -220,6 +242,5 @@ def test_application_group_required_fields(mail_user):
     assert application_group["type"] == "application"
 
     get_action("group_purge")(
-        context={"ignore_auth": True},
-        data_dict={"id": application_group["name"]}
+        context={"ignore_auth": True}, data_dict={"id": application_group["name"]}
     )

--- a/ckan-backend-dev/src/ckanext-wri/ckanext/wri/tests/test_dataset_permissions.py
+++ b/ckan-backend-dev/src/ckanext-wri/ckanext/wri/tests/test_dataset_permissions.py
@@ -6,11 +6,17 @@ import ckan.tests.factories as factories
 import unittest.mock as mock
 import uuid
 
+
 @mock.patch("ckan.plugins.toolkit.mail_user")
 @pytest.mark.usefixtures("with_plugins", "test_request_context")
 def test_package_create_public(mail_user):
     organization_dict = factories.Organization()
-    group_dict = factories.Group()
+    group_dict = factories.Group(
+        type="application",
+        homepage_url="http://example.com",
+        title="Test Group",
+        description="A description of the group",
+    )
 
     userobj_sysadmin = factories.Sysadmin()
     userobj_org_admin = factories.User()
@@ -94,7 +100,6 @@ def test_package_create_public(mail_user):
         "language": "en",
         "owner_org": organization_dict["id"],
         "project": "American Cities Climate Challenge: Renewables Accelerator (U.S. Energy)",
-        "application": "rw",
         "technical_notes": "http://example.com/technical_notes.pdf",
         "tag_string": "economy,mental health,government",
         "temporal_coverage_start": "2007",
@@ -116,6 +121,7 @@ def test_package_create_public(mail_user):
         "learn_more": "https://example.com/learn_more.pdf",
         "cautions": "This data should be used with caution because...",
         "methodology": "A short methodology of the dataset",
+        "groups": [{"id": group_dict["id"]}],
     }
 
     try:
@@ -186,6 +192,7 @@ def test_package_create_public(mail_user):
         )
     except NotFound:
         pass
+
 
 @mock.patch("ckan.plugins.toolkit.mail_user")
 @pytest.mark.usefixtures("with_plugins", "test_request_context")
@@ -275,7 +282,6 @@ def test_package_create_draft(mail_user):
         "language": "en",
         "owner_org": organization_dict["id"],
         "project": "American Cities Climate Challenge: Renewables Accelerator (U.S. Energy)",
-        "application": "rw",
         "technical_notes": "http://example.com/technical_notes.pdf",
         "tag_string": "economy,mental health,government",
         "temporal_coverage_start": "2007",
@@ -309,7 +315,7 @@ def test_package_create_draft(mail_user):
         )
     except NotFound:
         pass
-    
+
     result_create_draft = get_action("package_create")(
         context=context_org_editor, data_dict=dataset_draft
     )
@@ -322,13 +328,13 @@ def test_package_create_draft(mail_user):
 
     assert result_sysadmin_get_draft["name"] == dataset_draft["name"]
 
-   # Org admin
+    # Org admin
 
     with pytest.raises(NotAuthorized) as excinfo:
         result_org_admin_get_draft = get_action("package_show")(
             context=context_org_admin, data_dict={"id": result_create_draft["name"]}
         )
-        __import__('pprint').pprint(result_org_admin_get_draft)
+        __import__("pprint").pprint(result_org_admin_get_draft)
     assert "not authorized" in str(excinfo.value)
 
     # Org editor
@@ -348,7 +354,7 @@ def test_package_create_draft(mail_user):
 
     assert "not authorized" in str(excinfo.value)
 
-   # General user
+    # General user
 
     with pytest.raises(NotAuthorized) as excinfo:
         result_general_get_draft = get_action("package_show")(
@@ -371,6 +377,7 @@ def test_package_create_draft(mail_user):
         )
     except NotFound:
         pass
+
 
 @mock.patch("ckan.plugins.toolkit.mail_user")
 @pytest.mark.usefixtures("with_plugins", "test_request_context")
@@ -460,7 +467,6 @@ def test_package_create_internal(mail_user):
         "language": "en",
         "owner_org": organization_dict["id"],
         "project": "American Cities Climate Challenge: Renewables Accelerator (U.S. Energy)",
-        "application": "rw",
         "technical_notes": "http://example.com/technical_notes.pdf",
         "tag_string": "economy,mental health,government",
         "temporal_coverage_start": "2007",
@@ -494,7 +500,6 @@ def test_package_create_internal(mail_user):
         )
     except NotFound:
         pass
-
 
     result_create_internal = get_action("package_create")(
         context=context_sysadmin, data_dict=dataset_internal
@@ -558,6 +563,7 @@ def test_package_create_internal(mail_user):
         )
     except NotFound:
         pass
+
 
 @mock.patch("ckan.plugins.toolkit.mail_user")
 @pytest.mark.usefixtures("with_plugins", "test_request_context")
@@ -647,7 +653,6 @@ def test_package_create_private(mail_user):
         "language": "en",
         "owner_org": organization_dict["id"],
         "project": "American Cities Climate Challenge: Renewables Accelerator (U.S. Energy)",
-        "application": "rw",
         "technical_notes": "http://example.com/technical_notes.pdf",
         "tag_string": "economy,mental health,government",
         "temporal_coverage_start": "2007",
@@ -685,7 +690,6 @@ def test_package_create_private(mail_user):
     result_create_private = get_action("package_create")(
         context=context_sysadmin, data_dict=dataset_private
     )
-
 
     # Sysadmin
 

--- a/ckan-backend-dev/src/ckanext-wri/ckanext/wri/tests/test_pending_datasets.py
+++ b/ckan-backend-dev/src/ckanext-wri/ckanext/wri/tests/test_pending_datasets.py
@@ -7,7 +7,9 @@ import unittest.mock as mock
 
 
 @mock.patch("ckan.plugins.toolkit.mail_user")
-@pytest.mark.usefixtures("with_plugins", "test_request_context")
+@pytest.mark.usefixtures(
+    "with_plugins", "test_request_context"
+)
 def test_pending_dataset_create(mail_user):
     user = factories.Sysadmin()
     dataset = factories.Dataset(
@@ -36,7 +38,9 @@ def test_pending_dataset_create(mail_user):
 
 
 @mock.patch("ckan.plugins.toolkit.mail_user")
-@pytest.mark.usefixtures("with_plugins", "test_request_context")
+@pytest.mark.usefixtures(
+    "with_plugins", "test_request_context"
+)
 def test_pending_dataset_show(mail_user):
     user = factories.Sysadmin()
     dataset = factories.Dataset(
@@ -67,7 +71,9 @@ def test_pending_dataset_show(mail_user):
 
 
 @mock.patch("ckan.plugins.toolkit.mail_user")
-@pytest.mark.usefixtures("with_plugins", "test_request_context")
+@pytest.mark.usefixtures(
+    "with_plugins", "test_request_context"
+)
 def test_pending_dataset_update(mail_user):
     user = factories.Sysadmin()
     dataset = factories.Dataset(
@@ -111,7 +117,9 @@ def test_pending_dataset_update(mail_user):
 
 
 @mock.patch("ckan.plugins.toolkit.mail_user")
-@pytest.mark.usefixtures("with_plugins", "test_request_context")
+@pytest.mark.usefixtures(
+    "with_plugins", "test_request_context"
+)
 def test_pending_dataset_delete(mail_user):
     user = factories.Sysadmin()
     dataset = factories.Dataset(
@@ -149,7 +157,9 @@ def test_pending_dataset_delete(mail_user):
 
 
 @mock.patch("ckan.plugins.toolkit.mail_user")
-@pytest.mark.usefixtures("with_plugins", "test_request_context")
+@pytest.mark.usefixtures(
+    "with_plugins", "test_request_context"
+)
 def test_pending_diff_show(mail_user):
     userobj_sysadmin = factories.Sysadmin()
     session = model.Session
@@ -162,11 +172,10 @@ def test_pending_diff_show(mail_user):
     dataset_public = {
         "type": "dataset",
         "title": "Test Dataset Schema",
-        "name": f"public-dataset",
+        "name": "public-dataset",
         "url": "http://example.com/dataset.json",
         "language": "en",
         "project": "American Cities Climate Challenge: Renewables Accelerator (U.S. Energy)",
-        "application": "rw",
         "technical_notes": "http://example.com/technical_notes.pdf",
         "tag_string": "economy,mental health,government",
         "temporal_coverage_start": "2007",
@@ -190,6 +199,13 @@ def test_pending_diff_show(mail_user):
         "cautions": "This data should be used with caution because...",
         "methodology": "A short methodology of the dataset",
     }
+    try:
+        get_action("dataset_purge")(
+            context={"ignore_auth": True}, data_dict={"id": dataset_public["name"]}
+        )
+    except Exception:
+        pass
+
     result_create_public = get_action("package_create")(
         context=context_sysadmin, data_dict=dataset_public
     )
@@ -220,3 +236,7 @@ def test_pending_diff_show(mail_user):
     assert result["title"]["new_value"] == "New Title"
     assert result["notes"]["new_value"] == "New description"
     assert result["wri_data"]["new_value"] is True
+
+    get_action("dataset_purge")(
+        context={"ignore_auth": True}, data_dict={"id": result_sysadmin_get_public["name"]}
+    )

--- a/ckan-backend-dev/src/ckanext-wri/ckanext/wri/tests/test_schema.py
+++ b/ckan-backend-dev/src/ckanext-wri/ckanext/wri/tests/test_schema.py
@@ -21,6 +21,26 @@ def test_package_create(mail_user):
 
     organization_dict = factories.Organization()
     group_dict = factories.Group()
+    application_group_name = "test-application-group-schema"
+
+    try:
+        get_action("group_purge")(
+            context={"ignore_auth": True},
+            data_dict={"id": application_group_name}
+        )
+    except NotFound:
+        pass
+
+    application_group_dict = get_action("group_create")(
+        context=context,
+        data_dict={
+            "name": application_group_name,
+            "title": "Test Application Group Schema",
+            "description": "A description of the application group",
+            "homepage_url": "http://example.com",
+            "type": "application"
+        }
+    )
 
     dataset = {
         "type": "dataset",
@@ -30,8 +50,10 @@ def test_package_create(mail_user):
         "language": "en",
         "owner_org": organization_dict["id"],
         "project": "American Cities Climate Challenge: Renewables Accelerator (U.S. Energy)",
-        "application": "rw",
-        "groups": [{"id": group_dict["id"]}],
+        "groups": [
+            {"id": application_group_dict["id"]},
+            {"id": group_dict["id"]}
+        ],
         "technical_notes": "http://example.com/technical_notes.pdf",
         "tag_string": "economy,mental health,government",
         "temporal_coverage_start": "2007",
@@ -53,11 +75,11 @@ def test_package_create(mail_user):
         "reason_for_adding": "This data is being added because...",
         "learn_more": "https://example.com/learn_more.pdf",
         "cautions": "This data should be used with caution because...",
-        "methodology": "A short methodology of the dataset"
+        "methodology": "A short methodology of the dataset",
     }
 
     try:
-        get_action("package_delete")(
+        get_action("dataset_purge")(
             context={"ignore_auth": True},
             data_dict={"id": dataset["name"]}
         )
@@ -71,13 +93,20 @@ def test_package_create(mail_user):
 
     tag_string = dataset["tag_string"].split(",")
 
+    context.pop("for_create", None)
+    context.pop("for_approval", None)
+
+    result = get_action("package_show")(
+        context=context,
+        data_dict={"id": dataset["name"]}
+    )
+
     assert result["title"] == dataset["title"]
     assert result["name"] == dataset["name"]
     assert result["url"] == dataset["url"]
     assert result["language"] == dataset["language"]
     assert result["owner_org"] == organization_dict["id"]
     assert result["project"] == dataset["project"]
-    assert result["application"] == dataset["application"]
     assert result["groups"][0]["name"] == group_dict["name"]
     assert result["technical_notes"] == dataset["technical_notes"]
     assert all(
@@ -103,6 +132,11 @@ def test_package_create(mail_user):
     assert result["learn_more"] == dataset["learn_more"]
     assert result["cautions"] == dataset["cautions"]
     assert result["methodology"] == dataset["methodology"]
+    assert application_group_dict["id"] in [group["id"] for group in result["applications"]]
+    assert application_group_dict["name"] in [group["name"] for group in result["applications"]]
+    assert application_group_dict["title"] in [group["title"] for group in result["applications"]]
+    assert application_group_dict["type"] in [group["type"] for group in result["applications"]]
+    assert application_group_dict["homepage_url"] in [group["homepage_url"] for group in result["applications"]]
 
     invalid_urls = ["invalid_url_1", "invalid_url_2", "invalid_url_3"]
 
@@ -132,9 +166,17 @@ def test_package_create(mail_user):
     assert "Value must be a valid ISO 639-1 language code" in str(excinfo.value)
 
     try:
-        get_action("package_delete")(
+        get_action("dataset_purge")(
             context={"ignore_auth": True},
             data_dict={"id": dataset["name"]}
+        )
+    except NotFound:
+        pass
+
+    try:
+        get_action("group_purge")(
+            context={"ignore_auth": True},
+            data_dict={"id": application_group_dict["name"]}
         )
     except NotFound:
         pass

--- a/ckan-backend-dev/src/ckanext-wri/ckanext/wri/tests/test_search.py
+++ b/ckan-backend-dev/src/ckanext-wri/ckanext/wri/tests/test_search.py
@@ -32,7 +32,6 @@ def test_search_queries(mail_user):
         "language": "en",
         "owner_org": organization_dict["id"],
         "project": "American Cities Climate Challenge: Renewables Accelerator (U.S. Energy)",
-        "application": "rw app",
         "groups": [{"id": group_dict["id"]}],
         "technical_notes": "http://example.com/technical_notes.pdf",
         "tag_string": "economy,mental health,government",
@@ -69,7 +68,6 @@ def test_search_queries(mail_user):
     fields_to_test = [
         "language",
         "project",
-        "application",
         "technical_notes",
         # 'temporal_coverage_start', 'temporal_coverage_end',
         "update_frequency",

--- a/ckan-backend-dev/src/ckanext-wri/test.ini
+++ b/ckan-backend-dev/src/ckanext-wri/test.ini
@@ -8,9 +8,10 @@ use = config:../../src/ckan/test-core.ini
 
 # Insert any custom config settings to be used when running your extension's
 # tests here. These will override the one defined in CKAN core's test-core.ini
-ckan.plugins = wri scheming_datasets
+ckan.plugins = wri scheming_datasets scheming_groups
 scheming.dataset_schemas = ckanext.wri.schema:ckan_dataset.yaml
 scheming.presets = ckanext.wri.schema:presets.json
+scheming.group_schemas = ckanext.wri.schema:wri_application.json
 api_token.jwt.algorithm = RS256
 api_token.jwt.encode.secret = file:/srv/app/jwtRS256.key
 api_token.jwt.decode.secret = file:/srv/app/jwtRS256.key.pub

--- a/deployment/helm-templates/values.yaml.dev.template
+++ b/deployment/helm-templates/values.yaml.dev.template
@@ -38,7 +38,7 @@ ckan:
       CKAN__AUTH__ALLOW_COLLABORATORS_TO_CHANGE_OWNER_ORG: "True"
       CKAN___SCHEMING__DATASET_SCHEMAS: ckanext.wri.schema:ckan_dataset.yaml
       CKAN___SCHEMING__ORGANIZATION_SCHEMAS: ckanext.scheming:custom_org_with_address.json
-      CKAN___SCHEMING__GROUP_SCHEMAS: ckanext.scheming:custom_group_with_status.json
+      CKAN___SCHEMING__GROUP_SCHEMAS: ckanext.wri.schema:wri_application.json
       CKAN___SCHEMING__PRESETS: ckanext.wri.schema:presets.json
       CKANEXT__AUTH__INCLUDE_FRONTEND_LOGIN_TOKEN: "True"
       CKAN__DATASTORE__SQLSEARCH__ENABLED: "True"


### PR DESCRIPTION
Per the recommendation by Luccas, `package_show` and `package_search` now output an `applications` field containing the application group objects (and they're removed from `groups`):

```
{
    "help":"http://ckan-dev:5000/private-admin/api/3/action/help_show?name=package_search",
    "success":true,
    "result":{
        "count":1,
        "facets":{
            
        },
        "results":[
            {
                ... other fields ...
                "groups":[
                    {
                        "description":"",
                        "display_name":"Test Group 1 image",
                        "id":"9c90f6bb-7917-4b8b-a16a-fb9268dc5b4d",
                        "image_display_url":"http://ckan-dev:5000/private-admin/uploads/group/2024-11-05-172158.361308abstract-conflict-geometric-pattern-4k.jpg",
                        "name":"test-group-1-image",
                        "title":"Test Group 1 image",
                        "type":"group"
                    }
                ],
                ... other fields ...
                "applications":[
                    {
                        "description":"My Application",
                        "display_name":"My First Application",
                        "id":"4d48f886-a594-4ea6-864e-ef6aa5aed34f",
                        "image_display_url":"http://ckan-dev:5000/private-admin/uploads/group/2024-11-05-172629.288452103720-flowers-purple-4k-copy.jpg",
                        "name":"my-first-application",
                        "title":"My First Application",
                        "type":"application",
                        "contact_url":"http://example.com/my-organization/contact",
                        "image_url":"2024-11-05-172629.288452103720-flowers-purple-4k-copy.jpg",
                        "help_url":"http://example.com/my-organization/help",
                        "homepage_url":"http://example.com/my-organization"
                    }
                ]
            }
        ],
        "sort":"score desc, metadata_modified desc",
        "search_facets":{
            
        }
    }
}
```

And I added a few `pytest` tests to check creation, validation, etc.