### PR TITLE
Add bulk purge collaborator issue patch

### DIFF
--- a/ckan-backend-dev/ckan/patches/ckan/03_fix_dataset_purge_collaborators.patch
+++ b/ckan-backend-dev/ckan/patches/ckan/03_fix_dataset_purge_collaborators.patch
@@ -1,0 +1,19 @@
+diff --git a/ckan/logic/action/delete.py b/ckan/logic/action/delete.py
+index dc3ce8ec2..1828effca 100644
+--- a/ckan/logic/action/delete.py
++++ b/ckan/logic/action/delete.py
+@@ -152,6 +152,14 @@ def dataset_purge(context: Context, data_dict: DataDict) -> ActionResult.Dataset
+                 model.PackageRelationship.object_package_id == pkg.id)).all():
+         r.purge()
+ 
++    dataset_collaborators = (
++        model.Session.query(model.PackageMember)
++        .filter(model.PackageMember.package_id == id)
++        .all()
++    )
++    for collaborator in dataset_collaborators:
++        collaborator.delete()
++
+     pkg = model.Package.get(id)
+     assert pkg
+     pkg.purge()

--- a/deployment/ckan/patches/ckan/03_fix_dataset_purge_collaborators.patch
+++ b/deployment/ckan/patches/ckan/03_fix_dataset_purge_collaborators.patch
@@ -1,0 +1,19 @@
+diff --git a/ckan/logic/action/delete.py b/ckan/logic/action/delete.py
+index dc3ce8ec2..1828effca 100644
+--- a/ckan/logic/action/delete.py
++++ b/ckan/logic/action/delete.py
+@@ -152,6 +152,14 @@ def dataset_purge(context: Context, data_dict: DataDict) -> ActionResult.Dataset
+                 model.PackageRelationship.object_package_id == pkg.id)).all():
+         r.purge()
+ 
++    dataset_collaborators = (
++        model.Session.query(model.PackageMember)
++        .filter(model.PackageMember.package_id == id)
++        .all()
++    )
++    for collaborator in dataset_collaborators:
++        collaborator.delete()
++
+     pkg = model.Package.get(id)
+     assert pkg
+     pkg.purge()


### PR DESCRIPTION
The current issue can be replicated by following these steps:
- Delete a dataset
- Manually navigate to the deleted dataset edit page (or go to the trash and click on it, then edit)
- Add a new collaborator
- Try to purge the dataset

The above should fail before applying the patch.

It looks like [package_delete removes collaborators, but dataset_purge doesn't](https://github.com/ckan/ckan/blob/f03e7f7d02397b064a29a5c737fa4a72b8a30191/ckan/logic/action/delete.py#L72-L158):
```
def package_delete(context: Context, data_dict: DataDict) -> ActionResult.PackageDelete:
    '''Delete a dataset (package).

    This makes the dataset disappear from all web & API views, apart from the
    trash.

    You must be authorized to delete the dataset.

    :param id: the id or name of the dataset to delete
    :type id: string

    '''
    model = context['model']
    id = _get_or_bust(data_dict, 'id')

    entity = model.Package.get(id)

    if entity is None:
        raise NotFound

    _check_access('package_delete', context, data_dict)

    for item in plugins.PluginImplementations(plugins.IPackageController):
        item.delete(entity)

        item.after_dataset_delete(context, data_dict)

    entity.delete()

    dataset_memberships = model.Session.query(model.Member).filter(
        model.Member.table_id == id).filter(
        model.Member.state == 'active').all()

    for membership in dataset_memberships:
        membership.delete()

    dataset_collaborators = model.Session.query(model.PackageMember).filter(
        model.PackageMember.package_id == id).all()
    for collaborator in dataset_collaborators:
        collaborator.delete()

    model.repo.commit()


def dataset_purge(context: Context, data_dict: DataDict) -> ActionResult.DatasetPurge:
    '''Purge a dataset.

    .. warning:: Purging a dataset cannot be undone!

    Purging a database completely removes the dataset from the CKAN database,
    whereas deleting a dataset simply marks the dataset as deleted (it will no
    longer show up in the front-end, but is still in the db).

    You must be authorized to purge the dataset.

    :param id: the name or id of the dataset to be purged
    :type id: string

    '''
    from sqlalchemy import or_

    model = context['model']
    id = _get_or_bust(data_dict, 'id')

    pkg = model.Package.get(id)
    if pkg is None:
        raise NotFound('Dataset was not found')
    context['package'] = pkg

    _check_access('dataset_purge', context, data_dict)

    members = model.Session.query(model.Member) \
                   .filter(model.Member.table_id == pkg.id) \
                   .filter(model.Member.table_name == 'package')
    if members.count() > 0:
        for m in members.all():
            m.purge()

    for r in model.Session.query(model.PackageRelationship).filter(
            or_(model.PackageRelationship.subject_package_id == pkg.id,
                model.PackageRelationship.object_package_id == pkg.id)).all():
        r.purge()

    pkg = model.Package.get(id)
    assert pkg
    pkg.purge()
    model.repo.commit_and_remove()
```

So, when you add a collaborator to the dataset after it’s deleted, the collaborators don’t get removed on purge.

There's actually [an open issue about this from 5 years ago](https://github.com/ckan/ckan/issues/5582), and it's still not resolved. If this patch works well, I can open a PR in the CKAN core repo for it. 