### PR TITLE
[Dev] Increase proxy-read-timeout to avoid early external request disconnects

### DIFF
--- a/deployment/helm-templates/templates/wri-dev-ingress-fe-internal-api.yaml
+++ b/deployment/helm-templates/templates/wri-dev-ingress-fe-internal-api.yaml
@@ -16,7 +16,7 @@ metadata:
     nginx.ingress.kubernetes.io/limit-rps: "50"
     nginx.ingress.kubernetes.io/proxy-body-size: 1000M
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "60"
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"
     nginx.ingress.kubernetes.io/rewrite-target: /api/action/$1
     nginx.ingress.kubernetes.io/use-regex: "true"
   labels:

--- a/deployment/helm-templates/templates/wri-dev-ingress-fe-internal-api.yaml
+++ b/deployment/helm-templates/templates/wri-dev-ingress-fe-internal-api.yaml
@@ -3,7 +3,6 @@ kind: Ingress
 metadata:
   annotations:
     cert-manager.io/cluster-issuer: cert-manager
-    kubernetes.io/ingress.class: nginx
     meta.helm.sh/release-name: dx-helm-wri-dev-release
     meta.helm.sh/release-namespace: wri-odp-dev
     nginx.ingress.kubernetes.io/configuration-snippet: |
@@ -17,7 +16,7 @@ metadata:
     nginx.ingress.kubernetes.io/limit-rps: "50"
     nginx.ingress.kubernetes.io/proxy-body-size: 1000M
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "60"
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
     nginx.ingress.kubernetes.io/rewrite-target: /api/action/$1
     nginx.ingress.kubernetes.io/use-regex: "true"
   labels:
@@ -25,6 +24,7 @@ metadata:
   name: wri-dev-ingress-fe-internal-api
   namespace: wri-odp-dev
 spec:
+  ingressClassName: nginx
   rules:
   - host: wri.dev.frontend.datopian.com
     http:


### PR DESCRIPTION
There was an additional change that isn't included in this PR (manually added `service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: 600` to the load balancer, which I can't find a deployment file for, so the setting should persist).

This change fixes errors during long external API calls. 10 minutes should be more than sufficient. One of the longest I've run into via testing is maybe 2-3 minutes.