### PR TITLE
Prefect - set PREFECT_UI_URL to fix notifications link

### DIFF
--- a/prefect-server/values.yaml
+++ b/prefect-server/values.yaml
@@ -8,3 +8,7 @@ ingress:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: cert-manager
   tls: true
+server:
+  env:
+  - name: PREFECT_UI_URL
+    value: "https://wri.dev.prefect.datopian.com"


### PR DESCRIPTION
This is already applied to the deployment, so no rush to get this deployed.

Just adding this environment variable to fix the URL shown (was showing `localhost:4200` instead of the real URL) in the Prefect notifications. The first notification is before updating the variable and the second is after:
![image](https://github.com/user-attachments/assets/c98acc63-c3c9-467c-ab0e-9c6ef7a2e0e3)
