### PR TITLE
ODP-594

### DIFF
--- a/ckan-backend-dev/src/ckanext-wri/ckanext/wri/logic/action/update.py
+++ b/ckan-backend-dev/src/ckanext-wri/ckanext/wri/logic/action/update.py
@@ -26,6 +26,8 @@ from ckan.common import _
 import json
 import requests
 from ckanext.wri.logic.action.get import validate_visibility
+import json
+from typing import Any, Dict, List, Tuple
 
 # encoding: utf-8
 
@@ -287,9 +289,122 @@ def package_patch(context: Context, data_dict: DataDict):
             )
     return pending_update.get("package_data")
 
+def find_differences(original: Dict[str, Any], new: Dict[str, Any], path: str = "") -> List[Tuple[str, Any, Any]]:
+    """
+    Recursively find differences between two dictionaries.
+    
+    Returns:
+        List of tuples containing (field_path, original_value, new_value)
+    """
+    differences = []
+    
+    # Check all keys in both dictionaries
+    all_keys = set(original.keys()) | set(new.keys())
+    
+    for key in all_keys:
+        current_path = f"{path}.{key}" if path else key
+        
+        # Key only in original
+        if key in original and key not in new:
+            differences.append((current_path, original[key], None))
+        
+        # Key only in new
+        elif key not in original and key in new:
+            differences.append((current_path, None, new[key]))
+        
+        # Key in both - check values
+        else:
+            original_val = original[key]
+            new_val = new[key]
+            
+            # If both are dictionaries, recurse
+            if isinstance(original_val, dict) and isinstance(new_val, dict):
+                differences.extend(find_differences(original_val, new_val, current_path))
+            
+            # If both are lists, compare them
+            elif isinstance(original_val, list) and isinstance(new_val, list):
+                list_diffs = compare_lists(original_val, new_val, current_path)
+                differences.extend(list_diffs)
+
+                  # Consider equivalent "empty" values as equal
+            elif are_equivalent_empty_values(original_val, new_val):
+                pass
+            
+            elif original_val != new_val:
+                differences.append((current_path, original_val, new_val))
+    
+    return differences
+
+def are_equivalent_empty_values(val1: Any, val2: Any) -> bool:
+    empty_equivalents = [
+        (None, {}),
+        (None, "{}"),
+        ({}, None),
+        ("{}", None),
+        (None, []),
+        ([], None),
+        (None, ""),
+        ("", None),
+        ({}, []),
+        ("{}", []),
+        ([], {}),
+        ([], "{}"),
+    ]
+    
+    for a, b in empty_equivalents:
+        if (val1 == a and val2 == b) or (val1 == b and val2 == a):
+            return True
+    return False
+
+def compare_lists(original_list: List[Any], new_list: List[Any], path: str) -> List[Tuple[str, Any, Any]]:
+    """Compare two lists and find differences."""
+    differences = []
+    
+    # Compare lengths
+    if len(original_list) != len(new_list):
+        differences.append((f"{path}[length]", len(original_list), len(new_list)))
+    
+    # Compare elements up to the shorter length
+    min_length = min(len(original_list), len(new_list))
+    for i in range(min_length):
+        if isinstance(original_list[i], dict) and isinstance(new_list[i], dict):
+            differences.extend(find_differences(original_list[i], new_list[i], f"{path}[{i}]"))
+        elif original_list[i] != new_list[i]:
+            differences.append((f"{path}[{i}]", original_list[i], new_list[i]))
+    
+    # Handle extra elements in longer list
+    if len(original_list) > min_length:
+        for i in range(min_length, len(original_list)):
+            differences.append((f"{path}[{i}]", original_list[i], None))
+    
+    if len(new_list) > min_length:
+        for i in range(min_length, len(new_list)):
+            differences.append((f"{path}[{i}]", None, new_list[i]))
+    
+    return differences
+
+def only_ignored_fields_changed(original_pkg, new_pkg):
+    ignore_fields = {
+        'approval_status',
+        'metadata_modified',
+        'schema'
+    }
+    differences = find_differences(original_pkg, new_pkg)
+    # Filter out ignored fields (by field path suffix)
+    differences = [
+        d for d in differences if not any(d[0].endswith(field) for field in ignore_fields)
+    ]
+    if len(differences) > 0:
+        log.info(f"Differences: {differences[0]}")
+    if len(differences) == 0:
+        return True
+    for difference in differences:
+        log.info(f"Dataset {new_pkg['name']} has changed field {difference[0]} from {difference[1]} to {difference[2]}")
+    return False
 
 # IMPORTANT: This function includes an override/change for authors/maintainers (the call to stringify_actor_objects).
 # This is not a 1:1 match with the original function, though all other logic is the same.
+# Besides that, it also includes a check to see if only the approval_status field was changed
 def old_package_update(context: Context, data_dict: DataDict) -> ActionResult.PackageUpdate:
     """Update a dataset (package).
 
@@ -327,6 +442,7 @@ def old_package_update(context: Context, data_dict: DataDict) -> ActionResult.Pa
         raise ValidationError({"id": _("Missing value")})
 
     pkg = model.Package.get(name_or_id)
+    old_pkg = tk.get_action("package_show")(context, {"id": name_or_id})
     if pkg is None:
         raise NotFound(_("Package was not found."))
     context["package"] = pkg
@@ -442,6 +558,15 @@ def old_package_update(context: Context, data_dict: DataDict) -> ActionResult.Pa
             context, {"id": data_dict["id"], "include_plugin_data": include_plugin_data}
         )
     )
+    new_pkg = tk.get_action("package_show")(context, {"id": data_dict["id"]})
+    if only_ignored_fields_changed(old_pkg, new_pkg):
+        log.info("Only ignored fields changed, making sure metadata_modified is not updated")
+        context['original_metadata_modified'] = old_pkg['metadata_modified']
+        model.Session.query(model.Package).filter_by(
+                        id=pkg.id
+        ).update({"metadata_modified": old_pkg['metadata_modified']})
+        model.Session.commit()
+        output['metadata_modified'] = old_pkg['metadata_modified']
     return output
 
 

--- a/ckan-backend-dev/src/ckanext-wri/ckanext/wri/plugin.py
+++ b/ckan-backend-dev/src/ckanext-wri/ckanext/wri/plugin.py
@@ -382,8 +382,6 @@ class WriPlugin(plugins.SingletonPlugin):
             log.critical(e)
             pass
 
-    # IPackageController
-
     def after_dataset_create(self, context, pkg_dict):
         if pkg_dict.get("resources") is not None:
             for resource in pkg_dict.get("resources"):
@@ -393,6 +391,17 @@ class WriPlugin(plugins.SingletonPlugin):
         #     ResourceLocation.index_dataset_resources_by_location(pkg_dict, False)
 
     def after_dataset_update(self, context, pkg_dict):
+        # We want to ignore changes when its only setting approve to pending
+        if context.get('original_metadata_modified'):
+            model = context['model']
+            original_timestamp = context.get('original_metadata_modified')
+            if original_timestamp:
+                model.Session.query(model.Package).filter_by(
+                    id=pkg_dict['id']
+                ).update({"metadata_modified": original_timestamp})
+                model.Session.commit()
+                # Update the returned dict to reflect the restored timestamp
+                pkg_dict['metadata_modified'] = original_timestamp.isoformat()
         if pkg_dict.get("resources") is not None:
             for resource in pkg_dict.get("resources"):
                 self._submit_to_datapusher(resource)  # TODO: uncomment
@@ -472,9 +481,6 @@ class WriPlugin(plugins.SingletonPlugin):
         # spatial field is geojson coordinate data, not needed in SOLR either
         pkg_dict.pop("extras_spatial", None)
         pkg_dict.pop("spatial", None)
-
-        print("PACKAGE DICT", flush=True)
-        print(pkg_dict, flush=True)
         return pkg_dict
 
     def before_dataset_search(self, search_params):

--- a/ckan-backend-dev/src/ckanext-wri/ckanext/wri/search/__init__.py
+++ b/ckan-backend-dev/src/ckanext-wri/ckanext/wri/search/__init__.py
@@ -133,7 +133,6 @@ class SolrSpatialFieldSearchBackend:
         ]
 
     def index_dataset(self, dataset_dict):
-        print("INDEXING DATASET", flush=True)
         wkt = None
         geom_from_metadata = dataset_dict.get("spatial")
         if not geom_from_metadata:

--- a/deployment/frontend/src/components/_shared/SimpleSelect.tsx
+++ b/deployment/frontend/src/components/_shared/SimpleSelect.tsx
@@ -3,182 +3,181 @@ import { Listbox, Transition } from '@headlessui/react'
 import { ChevronDownIcon } from '@heroicons/react/20/solid'
 import classNames from '@/utils/classnames'
 import {
-    Controller,
-    FieldValues,
-    Path,
-    PathValue,
-    UseFormReturn,
-    useForm,
+  Controller,
+  FieldValues,
+  Path,
+  PathValue,
+  UseFormReturn,
+  useForm,
 } from 'react-hook-form'
 
 export interface Option<V> {
-    label: string
-    value: V
-    default?: boolean
-    disbaled?: boolean
+  label: string
+  value: V
+  default?: boolean
+  disbaled?: boolean
 }
 
 interface SimpleSelectProps<T extends FieldValues, V extends Object> {
-    options: PathValue<T, Path<T> & Option<V>>[]
-    placeholder?: string
-    className?: string
-    maxWidth?: string
-    formObj?: UseFormReturn<T>
-    name: Path<T>
-    id?: string
+  options: PathValue<T, Path<T> & Option<V>>[]
+  placeholder?: string
+  className?: string
+  maxWidth?: string
+  formObj?: UseFormReturn<T>
+  name: Path<T>
+  id?: string
 }
 
 export default function SimpleSelect<T extends FieldValues, V extends Object>({
-    options,
-    placeholder,
-    className,
-    maxWidth = 'xl:max-w-[28rem]',
-    formObj,
-    name,
-    id,
-    onChange: _onChange = (val) => {},
-    disabled,
-    str,
+  options,
+  placeholder,
+  className,
+  maxWidth = 'xl:max-w-[28rem]',
+  formObj,
+  name,
+  id,
+  onChange: _onChange = (val) => { },
+  disabled,
+  str,
 }: SimpleSelectProps<T, V> & {
-    onChange?: (val: any) => void
-    disabled?: boolean
-    str?: boolean
+  onChange?: (val: any) => void
+  disabled?: boolean
+  str?: boolean
 }) {
-    const { control } = formObj ?? useForm()
-    return (
-        <Controller
-            control={control}
-            name={name}
-            defaultValue={
-                options.find((option) => option.default) ??
-                ({
-                    value: '',
-                    label: '',
-                } as PathValue<T, Path<T> & Option<V>>)
-            }
-            render={({ field: { onChange: setSelected, value: selected } }) => {
-                const selectedFull = options.find(
-                    (o) => o.value === (str ? selected : selected?.value)
-                )
-                console.log('SELECTED', selected)
-                return (
-                    <Listbox
-                        value={selected}
-                        onChange={(e) => {
-                            if (_onChange && e != null) {
-                                _onChange(e.value)
-                            }
-                            setSelected(str ? e.value : e)
-                        }}
-                        disabled={disabled}
-                    >
-                        {({ open }) => (
-                            <>
-                                <div
-                                    className={classNames(
-                                        'relative w-full',
-                                        maxWidth
-                                    )}
-                                >
-                                    <Listbox.Button
-                                        id={id}
-                                        className={classNames(
-                                            'relative text-left block w-full rounded-md border-0 px-5 py-3 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:border-b-2 focus:border-blue-800 focus:bg-slate-100 focus:ring-0 focus:ring-offset-0 sm:text-sm sm:leading-6',
-                                            className ?? '',
-                                            !placeholder ? 'min-h-[2.5rem]' : ''
-                                        )}
-                                    >
-                                        <span className="flex items-center gap-2 truncate">
-                                            <span
-                                                className={classNames(
-                                                    selected && selected.label
-                                                        ? ''
-                                                        : 'text-zinc-500',
-                                                    'truncate'
-                                                )}
-                                            >
-                                                {selected &&
-                                                selectedFull &&
-                                                (str ? true : selected.label)
-                                                    ? selectedFull.label
-                                                          .charAt(0)
-                                                          .toUpperCase() +
-                                                      selectedFull.label.slice(
-                                                          1
-                                                      )
-                                                    : placeholder}
-                                            </span>
-                                            {selected?.visibility ===
-                                                'private' &&
-                                                selected?.value !=
-                                                    'private' && <>&#128274;</>}
-                                        </span>
-                                        <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
-                                            <ChevronDownIcon
-                                                className="h-5 w-5 text-gray-400"
-                                                aria-hidden="true"
-                                            />
-                                        </span>
-                                    </Listbox.Button>
-
-                                    <Transition
-                                        show={open}
-                                        as={Fragment}
-                                        leave="transition ease-in duration-100"
-                                        leaveFrom="opacity-100"
-                                        leaveTo="opacity-0"
-                                    >
-                                        <Listbox.Options className="absolute z-50 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm">
-                                            {options.map((option) => (
-                                                <Listbox.Option
-                                                    key={option.value}
-                                                    disabled={option.disabled}
-                                                    className={({ active }) =>
-                                                        classNames(
-                                                            active
-                                                                ? 'bg-blue-800 text-white'
-                                                                : 'text-gray-900',
-                                                            `relative cursor-default select-none py-2 pl-3 pr-9 ${option.disabled ? 'opacity-50' : ''}`
-                                                        )
-                                                    }
-                                                    value={option}
-                                                >
-                                                    {({ selected, active }) => (
-                                                        <>
-                                                            <span
-                                                                className={classNames(
-                                                                    selected
-                                                                        ? 'font-semibold'
-                                                                        : 'font-normal',
-                                                                    'block truncate'
-                                                                )}
-                                                            >
-                                                                {option.label}
-                                                                {option?.visibility &&
-                                                                option.visibility ===
-                                                                    'private' &&
-                                                                option.value !=
-                                                                    'private' ? (
-                                                                    <span className="ml-1">
-                                                                        {' '}
-                                                                        &#128274;
-                                                                    </span>
-                                                                ) : (
-                                                                    ''
-                                                                )}
-                                                            </span>
-                                                        </>
-                                                    )}
-                                                </Listbox.Option>
-                                            ))}
-                                        </Listbox.Options>
-                                    </Transition>
-                                </div>
-                            </>
-                        )}
-                    </Listbox>
-                )
+  const { control } = formObj ?? useForm()
+  return (
+    <Controller
+      control={control}
+      name={name}
+      defaultValue={
+        options.find((option) => option.default) ??
+        ({
+          value: '',
+          label: '',
+        } as PathValue<T, Path<T> & Option<V>>)
+      }
+      render={({ field: { onChange: setSelected, value: selected } }) => {
+        const selectedFull = options.find(
+          (o) => o.value === (str ? selected : selected?.value)
+        )
+        return (
+          <Listbox
+            value={selected}
+            onChange={(e) => {
+              if (_onChange && e != null) {
+                _onChange(e.value)
+              }
+              setSelected(str ? e.value : e)
             }}
-        />
-    )
+            disabled={disabled}
+          >
+            {({ open }) => (
+              <>
+                <div
+                  className={classNames(
+                    'relative w-full',
+                    maxWidth
+                  )}
+                >
+                  <Listbox.Button
+                    id={id}
+                    className={classNames(
+                      'relative text-left block w-full rounded-md border-0 px-5 py-3 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:border-b-2 focus:border-blue-800 focus:bg-slate-100 focus:ring-0 focus:ring-offset-0 sm:text-sm sm:leading-6',
+                      className ?? '',
+                      !placeholder ? 'min-h-[2.5rem]' : ''
+                    )}
+                  >
+                    <span className="flex items-center gap-2 truncate">
+                      <span
+                        className={classNames(
+                          selected && selected.label
+                            ? ''
+                            : 'text-zinc-500',
+                          'truncate'
+                        )}
+                      >
+                        {selected &&
+                          selectedFull &&
+                          (str ? true : selected.label)
+                          ? selectedFull.label
+                            .charAt(0)
+                            .toUpperCase() +
+                          selectedFull.label.slice(
+                            1
+                          )
+                          : placeholder}
+                      </span>
+                      {selected?.visibility ===
+                        'private' &&
+                        selected?.value !=
+                        'private' && <>&#128274;</>}
+                    </span>
+                    <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
+                      <ChevronDownIcon
+                        className="h-5 w-5 text-gray-400"
+                        aria-hidden="true"
+                      />
+                    </span>
+                  </Listbox.Button>
+
+                  <Transition
+                    show={open}
+                    as={Fragment}
+                    leave="transition ease-in duration-100"
+                    leaveFrom="opacity-100"
+                    leaveTo="opacity-0"
+                  >
+                    <Listbox.Options className="absolute z-50 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm">
+                      {options.map((option) => (
+                        <Listbox.Option
+                          key={option.value}
+                          disabled={option.disabled}
+                          className={({ active }) =>
+                            classNames(
+                              active
+                                ? 'bg-blue-800 text-white'
+                                : 'text-gray-900',
+                              `relative cursor-default select-none py-2 pl-3 pr-9 ${option.disabled ? 'opacity-50' : ''}`
+                            )
+                          }
+                          value={option}
+                        >
+                          {({ selected, active }) => (
+                            <>
+                              <span
+                                className={classNames(
+                                  selected
+                                    ? 'font-semibold'
+                                    : 'font-normal',
+                                  'block truncate'
+                                )}
+                              >
+                                {option.label}
+                                {option?.visibility &&
+                                  option.visibility ===
+                                  'private' &&
+                                  option.value !=
+                                  'private' ? (
+                                  <span className="ml-1">
+                                    {' '}
+                                    &#128274;
+                                  </span>
+                                ) : (
+                                  ''
+                                )}
+                              </span>
+                            </>
+                          )}
+                        </Listbox.Option>
+                      ))}
+                    </Listbox.Options>
+                  </Transition>
+                </div>
+              </>
+            )}
+          </Listbox>
+        )
+      }}
+    />
+  )
 }


### PR DESCRIPTION
The main code changes are in `old_package_update`
<img width="1220" height="166" alt="image" src="https://github.com/user-attachments/assets/c89ddd8d-e9b7-4991-89e2-68939017760c" />
At the start of the action we grab an object with the old dataset
<img width="918" height="219" alt="image" src="https://github.com/user-attachments/assets/70d93f36-9860-4bc8-a835-0d642a209ffc" />
At the end we compare the changes, if they are not in one of the relevant fields, we update the `metadata_modified` field to the old value directly with sqlalchemy
<img width="990" height="259" alt="image" src="https://github.com/user-attachments/assets/c9151c54-7806-4d25-bfb4-1ecc3102e74e" />
One quirk that i couldnt quite figure out is this `schema` field always changing between `None` and `{}` so i added it to the list to ignore, i dont think this to be a problem because any relevant changes to the `schema` field will be with a path such
`resources[0].schema.fields[0].name_of_field`  and therefore wouldnt be ignored (We only ignore if the path for the change ends with one of those words.
<img width="1316" height="388" alt="image" src="https://github.com/user-attachments/assets/53e632b0-e350-40ad-bd55-8fc5c1bb0b1a" />


