### PR TITLE
ODP-568 unify the helm charts for all environments

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -673,4 +673,9 @@ jobs:
       - name: 'Deploy using Helm Upgrade'
         run: |
           set -e
-          helm upgrade -i dx-helm-wri-$BRANCH_NAME-release ./deployment/helm-templates -f ./deployment/helm-templates/values.yaml -n $PROJECT_NAME-$BRANCH_NAME --create-namespace --wait
+          helm upgrade -i dx-helm-wri-$BRANCH_NAME-release  \
+            ./deployment/helm-templates \
+            -f ./deployment/helm-templates/values.yaml \
+            -n $PROJECT_NAME-$BRANCH_NAME \
+            --create-namespace \
+            --wait

--- a/deployment/frontend/next.config.mjs
+++ b/deployment/frontend/next.config.mjs
@@ -41,7 +41,7 @@ const config = {
     },
     images: {
         domains: [
-            'wri-dev-ckan-svc',
+            'wri-odp-ckan-svc',
             'wri.dev.ckan.datopian.com',
             'wri.staging.ckan.datopian.com',
             'wri.prod.ckan.datopian.com',

--- a/deployment/helm-templates/templates/ingress-fe-internal-admin.yaml
+++ b/deployment/helm-templates/templates/ingress-fe-internal-admin.yaml
@@ -3,8 +3,6 @@ kind: Ingress
 metadata:
   annotations:
     cert-manager.io/cluster-issuer: cert-manager
-    meta.helm.sh/release-name: dx-helm-wri-dev-release
-    meta.helm.sh/release-namespace: wri-odp-dev
     nginx.ingress.kubernetes.io/configuration-snippet: |
       more_set_headers "server: hide";
       more_set_headers "X-Content-Type-Options: nosniff";
@@ -21,29 +19,28 @@ metadata:
     nginx.ingress.kubernetes.io/use-regex: "true"
   labels:
     app.kubernetes.io/managed-by: Helm
-  name: wri-dev-ingress-fe-internal-admin
-  namespace: wri-odp-dev
+  name: wri-odp-ingress-fe-internal-admin
 spec:
   ingressClassName: nginx
   rules:
-  - host: wri.dev.frontend.datopian.com
+  - host: {{ .Values.ckan.frontend.ingress.domain }}
     http:
       paths:
       - backend:
           service:
-            name: wri-dev-ckan-svc
+            name: wri-odp-ckan-svc
             port:
               number: 80
         path: /private-admin/(.*)
         pathType: ImplementationSpecific
       - backend:
           service:
-            name: wri-dev-ckan-svc
+            name: wri-odp-ckan-svc
             port:
               number: 80
         path: /private-admin
         pathType: ImplementationSpecific
   tls:
   - hosts:
-    - wri.dev.frontend.datopian.com
-    secretName: wri.dev.frontend.datopian.com
+    - {{ .Values.ckan.frontend.ingress.domain }}
+    secretName: {{ .Values.ckan.frontend.ingress.domain }}

--- a/deployment/helm-templates/templates/ingress-fe-internal-api.yaml
+++ b/deployment/helm-templates/templates/ingress-fe-internal-api.yaml
@@ -3,8 +3,6 @@ kind: Ingress
 metadata:
   annotations:
     cert-manager.io/cluster-issuer: cert-manager
-    meta.helm.sh/release-name: dx-helm-wri-dev-release
-    meta.helm.sh/release-namespace: wri-odp-dev
     nginx.ingress.kubernetes.io/configuration-snippet: |
       more_set_headers "server: hide";
       more_set_headers "X-Content-Type-Options: nosniff";
@@ -21,32 +19,31 @@ metadata:
     nginx.ingress.kubernetes.io/use-regex: "true"
   labels:
     app.kubernetes.io/managed-by: Helm
-  name: wri-dev-ingress-fe-internal-api
-  namespace: wri-odp-dev
+  name: wri-odp-ingress-fe-internal-api
 spec:
   ingressClassName: nginx
   rules:
-  - host: wri.dev.frontend.datopian.com
+  - host: {{ .Values.ckan.frontend.ingress.domain }}
     http:
       paths:
       - backend:
           service:
-            name: wri-dev-ckan-svc
+            name: wri-odp-ckan-svc
             port:
               number: 80
         path: /api/action/(.*)
         pathType: ImplementationSpecific
-  - host: wri.dev.frontend.datopian.com
+  - host: {{ .Values.ckan.frontend.ingress.domain }}
     http:
       paths:
       - backend:
           service:
-            name: wri-dev-ckan-svc
+            name: wri-odp-ckan-svc
             port:
               number: 80
         path: /api/3/action/(.*)
         pathType: ImplementationSpecific
   tls:
   - hosts:
-    - wri.dev.frontend.datopian.com
-    secretName: wri.dev.frontend.datopian.com
+    - {{ .Values.ckan.frontend.ingress.domain }}
+    secretName: {{ .Values.ckan.frontend.ingress.domain }}

--- a/deployment/helm-templates/templates/ingress-fe-internal.yaml
+++ b/deployment/helm-templates/templates/ingress-fe-internal.yaml
@@ -3,8 +3,6 @@ kind: Ingress
 metadata:
   annotations:
     cert-manager.io/cluster-issuer: cert-manager
-    meta.helm.sh/release-name: dx-helm-wri-dev-release
-    meta.helm.sh/release-namespace: wri-odp-dev
     nginx.ingress.kubernetes.io/configuration-snippet: |
       more_set_headers "server: hide";
       more_set_headers "X-Content-Type-Options: nosniff";
@@ -41,22 +39,21 @@ metadata:
   generation: 1
   labels:
     app.kubernetes.io/managed-by: Helm
-  name: wri-dev-ingress-fe-internal
-  namespace: wri-odp-dev
+  name: wri-odp-ingress-fe-internal
 spec:
   ingressClassName: nginx
   rules:
-  - host: wri.dev.frontend.datopian.com
+  - host: {{ .Values.ckan.frontend.ingress.domain }}
     http:
       paths:
       - backend:
           service:
-            name: wri-dev-frontend-svc
+            name: wri-odp-frontend-svc
             port:
               number: 80
         path: /(.*)
         pathType: ImplementationSpecific
   tls:
   - hosts:
-    - wri.dev.frontend.datopian.com
-    secretName: wri.dev.frontend.datopian.com
+    - {{ .Values.ckan.frontend.ingress.domain }}
+    secretName: {{ .Values.ckan.frontend.ingress.domain }}

--- a/deployment/helm-templates/values.yaml.dev.template
+++ b/deployment/helm-templates/values.yaml.dev.template
@@ -15,7 +15,7 @@ ckan:
       CKAN__SITE_URL: https://wri.dev.frontend.datopian.com
       CKAN_SITE_URL: https://wri.dev.frontend.datopian.com
       CKAN_HOMEPAGE_STYLE: "2"
-      CKAN__DATAPUSHER__URL: http://wri-dev-datapusher-svc:80/
+      CKAN__DATAPUSHER__URL: http://wri-odp-datapusher-svc:80/
       CKAN_SVC_PORT_80_TCP_PROTO: tcp
       CKAN__AUTH__ANON_CREATE_DATASET: "False"
       CKAN__AUTH__CREATE_DATASET_IF_NOT_IN_ORGANIZATION: "True"
@@ -111,6 +111,8 @@ ckan:
     replicaCount: 1
   frontend:
     enable: true
+    ingress:
+      domain: wri.dev.frontend.datopian.com
     hpa:
       enable: false
     resources:
@@ -131,7 +133,7 @@ ckan:
     autoscaling:
       enable: false
     customResource: true
-    projectId: wri-dev
+    projectId: wri-odp
     resources: {}
     useProductionCerts: true
   ingress:
@@ -161,7 +163,7 @@ ckan:
         paths:
           - path: /(.*)
             port: 80
-            service: wri-dev-ckan-svc
+            service: wri-odp-ckan-svc
     ingressNamespace: nginx-ingress
     ingressClass: nginx
     tls:


### PR DESCRIPTION
This pull request updates deployment configurations to standardize naming conventions from `wri-dev` to `wri-odp` and improve flexibility by introducing templating for ingress domains. The changes affect Helm templates, environment variables, and frontend configuration, making the setup more consistent and easier to manage across environments.

**Helm Template and Ingress Updates:**

* Renamed ingress template files and updated resource names, service names, and namespaces from `wri-dev` to `wri-odp` to reflect the new naming standard. [[1]](diffhunk://#diff-ce76a4f16b722a996e6bd8fc161489cc58df490142e1d6a50842d5c10175c4a9L24-R46) [[2]](diffhunk://#diff-ecb433c24f26349995056ac033c7bbb67e8bf8c85780d4acd7a06d02c55c9198L24-R49) [[3]](diffhunk://#diff-ad8dbf519c17927bb8bf8bc9ae5394d711740a7cd6ad1ddaee68269666253af6L44-R59)
* Removed hardcoded ingress domains and TLS secret names, replacing them with the templated value `{{ .Values.ckan.frontend.ingress.domain }}` for better flexibility and environment configuration. [[1]](diffhunk://#diff-ce76a4f16b722a996e6bd8fc161489cc58df490142e1d6a50842d5c10175c4a9L24-R46) [[2]](diffhunk://#diff-ecb433c24f26349995056ac033c7bbb67e8bf8c85780d4acd7a06d02c55c9198L24-R49) [[3]](diffhunk://#diff-ad8dbf519c17927bb8bf8bc9ae5394d711740a7cd6ad1ddaee68269666253af6L44-R59)

**Configuration and Environment Variable Changes:**

* Updated environment variable references and service names in `values.yaml.dev.template` from `wri-dev-*` to `wri-odp-*`, including `CKAN__DATAPUSHER__URL` and the main CKAN service. [[1]](diffhunk://#diff-2900c58e8ca33cca777a4008083828b42cd24c242a8596758061b1e6ad6ba7d2L18-R18) [[2]](diffhunk://#diff-2900c58e8ca33cca777a4008083828b42cd24c242a8596758061b1e6ad6ba7d2L164-R166)
* Added a new `ingress.domain` field under `frontend` in `values.yaml.dev.template` to allow domain customization via Helm values.
* Changed `projectId` in `values.yaml.dev.template` from `wri-dev` to `wri-odp` for consistency with the new naming convention.

**Frontend Configuration Update:**

* Updated allowed image domains in `next.config.mjs` from `wri-dev-ckan-svc` to `wri-odp-ckan-svc` to match the new service naming.

**Workflow and Deployment Script Formatting:**

* Improved readability of the Helm upgrade command in the GitHub Actions workflow by splitting long lines and maintaining consistent formatting.