### PR TITLE
ODP-619 Data api download failing - AWS SES started enforcing strict SNI

### DIFF
--- a/ckan-backend-dev/src/ckanext-wri/ckanext/wri/plugin.py
+++ b/ckan-backend-dev/src/ckanext-wri/ckanext/wri/plugin.py
@@ -99,6 +99,35 @@ import json
 log = logging.getLogger(__name__)
 
 
+# CKAN core calls ``smtplib.SMTP("host:port")`` in ``ckan.lib.mailer``. CPython's
+# ``smtplib.SMTP.__init__`` assigns the *raw* ``host`` argument to ``self._host``
+# before ``connect()`` strips the ``:port`` suffix, so ``self._host`` retains the
+# port. ``starttls()`` later passes ``server_hostname=self._host`` as the TLS SNI
+# value, which AWS SES rejects with ``SSLV3_ALERT_ILLEGAL_PARAMETER`` because the
+# SNI must be a valid DNS name. Strip a trailing ``:<port>`` after construction
+# so SNI is well-formed. Safe for any SMTP server, not just SES.
+def _install_smtplib_sni_fix() -> None:
+    import smtplib
+
+    if getattr(smtplib.SMTP.__init__, "_wri_sni_patch", False):
+        return
+
+    _orig_smtp_init = smtplib.SMTP.__init__
+
+    def _smtp_init(self, host="", *args, **kwargs):
+        _orig_smtp_init(self, host, *args, **kwargs)
+        h = getattr(self, "_host", "") or ""
+        if h.count(":") == 1:
+            self._host = h.split(":", 1)[0]
+
+    _smtp_init._wri_sni_patch = True
+    smtplib.SMTP.__init__ = _smtp_init
+    smtplib.SMTP_SSL.__init__ = _smtp_init
+
+
+_install_smtplib_sni_fix()
+
+
 class WriPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IConfigurer)
     plugins.implements(plugins.IConfigurable)


### PR DESCRIPTION
# What's always been broken
CKAN's ckan/lib/mailer.py builds the SMTP client roughly like this (unchanged for many releases, including 2.11):

smtp_connection = smtplib.SMTP(config.get('smtp.server'))
where smtp.server = "email-smtp.us-east-1.amazonaws.com:587". And CPython's smtplib.SMTP.__init__ literally does self._host = host, keeping the raw "host:port" string. Then starttls() passes that whole string as server_hostname= (the SNI).

This has been a known CPython bug since December 2015 — [python/cpython#70039: "smtplib's SMTP.connect() should store the server name in ._host for .starttls()"](https://github.com/python/cpython/issues/70039). One of the early comments on that issue (gigaplastik, 2016) literally calls out:

Since the host is allowed to be supplied in 'hostname:port' format the assignment to ._host should be made after checking (and probably parsing) this format… Currently, the only server names supported are DNS hostnames; Literal IPv4 and IPv6 addresses are not permitted in [HostName].

So your TLS client was always sending an invalid SNI. Nothing in CKAN, your plugin, your Helm/k8s config, or your env vars regressed.

## What actually changed
Two things converged in early 2026:

AWS SES started enforcing strict SNI. Previously, SES's TLS terminator was lenient — it would accept (or silently ignore) the hostname:port SNI value and complete the handshake. At some point they tightened the front-end and any non-DNS SNI is now answered with SSLV3_ALERT_ILLEGAL_PARAMETER. That's the exact alert in your traceback.

The CKAN community noticed all at once. This was filed on Feb 25, 2026 as [ckan/ckan#9273: "AWS SES cannot be used by mailer.py anymore."](https://github.com/ckan/ckan/issues/9273) — and that bug report is what finally got attention on the dusty CPython issue.

CPython merged the fix on April 8, 2026, but only into main, with backports queued for 3.13 ([#148272](https://github.com/python/cpython/pull/148272)) and 3.14 ([#148273](https://github.com/python/cpython/pull/148273)). Your container runs Python 3.11.12 — Python 3.11 is in security-only mode now and will not get this fix. So upgrading CKAN alone won't help; you'd need to either move off 3.11 (when 3.13/3.14 ships the backport) or carry a workaround.

### So why didn't you see it before today
You probably didn't change anything between "working" and "broken." It broke the moment SES rolled out their stricter SNI check to the endpoint your pods talk to (email-smtp.us-east-1.amazonaws.com). AWS rolls these things out by region and over time, which is why some shops noticed in Feb and others later.
A pod restart, rollout, or DNS re-resolution will move you onto whichever SES front-end is enforcing the stricter check — which is why this can appear to "suddenly" start failing without any code change on your side.
Other transports (Gmail, Mailgun, SendGrid, plain Postfix relays) are still lax about SNI, so a CKAN install pointed at those mail providers wouldn't show the bug. The combination of CKAN's smtp.server = host:port config style plus AWS SES plus STARTTLS is what surfaces it.
What the patch in plugin.py does about it
Since you can't get a Python 3.11 patch release with the fix, and you don't want to fork CKAN core, the monkey-patch in _install_smtplib_sni_fix() is exactly the workaround the upstream issue suggests: strip the :port from self._host after __init__, so starttls() passes a clean DNS name as SNI. It mirrors what CPython's [PR #115259](https://github.com/python/cpython/pull/115259) does, just localized to your extension so it loads before any mail_recipient call.

Once 3.13/3.14 ships with the backport and you move to that base image, you can delete the patch. Until then it's the right fix.