### PR TITLE
chore(deps): Dependabot batch updates (Jul 2026)

### DIFF
--- a/ckan-backend-dev/src/ckanext-wri/requirements.txt
+++ b/ckan-backend-dev/src/ckanext-wri/requirements.txt
@@ -1,4 +1,4 @@
 pycountry==23.12.11
 Shapely==2.1.2
 GeoAlchemy2==0.20.0
-numpy>=1.14,<2.0.0
+numpy>=1.26.4,<2.0.0

--- a/datapusher/requirements.txt
+++ b/datapusher/requirements.txt
@@ -7,7 +7,7 @@ python-dateutil==2.9.0.post0
 pytz==2023.4
 python-dotenv==1.0.0
 psycopg2-binary==2.9.12
-boto3==1.43.38
+boto3==1.43.39
 pandas==2.3.3
 openpyxl==3.1.5
 lxml==6.0.4

--- a/datapusher/requirements.txt
+++ b/datapusher/requirements.txt
@@ -10,6 +10,6 @@ psycopg2-binary==2.9.12
 boto3==1.43.38
 pandas==2.3.3
 openpyxl==3.1.5
-lxml==6.0.4
+lxml==6.1.1
 geopandas==0.14.4
 tqdm==4.68.3

--- a/datapusher/requirements.txt
+++ b/datapusher/requirements.txt
@@ -5,7 +5,7 @@ pydantic>=2.13.4,<3
 datasize==1.0.0
 python-dateutil==2.9.0.post0
 pytz==2023.4
-python-dotenv==1.0.0
+python-dotenv==1.2.2
 psycopg2-binary==2.9.12
 boto3==1.43.38
 pandas==2.3.3

--- a/deployment/frontend/package-lock.json
+++ b/deployment/frontend/package-lock.json
@@ -57,7 +57,7 @@
                 "@trpc/react-query": "^10.37.1",
                 "@trpc/server": "^10.45.4",
                 "@turf/turf": "^7.1.0",
-                "@types/flexsearch": "^0.7.42",
+                "@types/flexsearch": "0.7.42",
                 "@types/mdx": "^2.0.13",
                 "@types/nprogress": "^0.2.3",
                 "@uppy/aws-s3": "^5.1.0",
@@ -175,15 +175,14 @@
             }
         },
         "node_modules/@aws-sdk/checksums": {
-            "version": "3.1000.10",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.10.tgz",
-            "integrity": "sha512-OUNjNcyA8Ai2OdlRUxW5jHUf6XJmqqZk3UddL+mDiUCtXrVqdmIHHkdDFWBlBRjhore/3ZBMgRXgcS0ggtvD0Q==",
-            "license": "Apache-2.0",
+            "version": "3.1000.11",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.11.tgz",
+            "integrity": "sha512-nW5kNBJBwVxkvBqygBYksS8WUFDO8Ad8OSfsVa+f5KFRRTrHL1rnWZNsWBwc5fC9YvZbET/57+X4hym/jKfV+g==",
             "dependencies": {
-                "@aws-sdk/core": "^3.974.25",
-                "@aws-sdk/types": "^3.973.14",
-                "@smithy/core": "^3.28.0",
-                "@smithy/types": "^4.15.0",
+                "@aws-sdk/core": "^3.974.26",
+                "@aws-sdk/types": "^3.973.15",
+                "@smithy/core": "^3.29.0",
+                "@smithy/types": "^4.15.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -191,21 +190,20 @@
             }
         },
         "node_modules/@aws-sdk/client-s3": {
-            "version": "3.1077.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1077.0.tgz",
-            "integrity": "sha512-yWK6jOMrMUgGarXlrQaAopWXva20NaOqTPApuE68SzsBFQ57fQ5E13BKUPLwtPgymk+8L6vG/O4h7Q30IBYr2w==",
-            "license": "Apache-2.0",
+            "version": "3.1078.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1078.0.tgz",
+            "integrity": "sha512-uQMPma3CzTXPKrRfTkhdKLfXocGoEJwBePcI/ca9iWF+re2gbFSDVV9EIcOrK8ke1OV3Jw4ejNmfmgRVlI5b9A==",
             "dependencies": {
-                "@aws-sdk/checksums": "^3.1000.10",
-                "@aws-sdk/core": "^3.974.25",
-                "@aws-sdk/credential-provider-node": "^3.972.60",
-                "@aws-sdk/middleware-sdk-s3": "^3.972.56",
-                "@aws-sdk/signature-v4-multi-region": "^3.996.37",
-                "@aws-sdk/types": "^3.973.14",
-                "@smithy/core": "^3.28.0",
-                "@smithy/fetch-http-handler": "^5.6.1",
-                "@smithy/node-http-handler": "^4.9.1",
-                "@smithy/types": "^4.15.0",
+                "@aws-sdk/checksums": "^3.1000.11",
+                "@aws-sdk/core": "^3.974.26",
+                "@aws-sdk/credential-provider-node": "^3.972.61",
+                "@aws-sdk/middleware-sdk-s3": "^3.972.57",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.38",
+                "@aws-sdk/types": "^3.973.15",
+                "@smithy/core": "^3.29.0",
+                "@smithy/fetch-http-handler": "^5.6.2",
+                "@smithy/node-http-handler": "^4.9.2",
+                "@smithy/types": "^4.15.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -213,17 +211,16 @@
             }
         },
         "node_modules/@aws-sdk/core": {
-            "version": "3.974.25",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.25.tgz",
-            "integrity": "sha512-fJFkx6u6wCqGMV/v6EAxiwa2UzEukbvr1hNPv4MrD3yj4IFz011jZg42/eSTOP/u5kJ0tlILqEjCWtT8GiKZvA==",
-            "license": "Apache-2.0",
+            "version": "3.974.26",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.26.tgz",
+            "integrity": "sha512-wRj7Pthvjk3anees97pUWlxlTa0DUjeGrEQU5fKDZVdWZV0ekaprbof0df2uaE9g8u67t035v2j+ne2AW2UMkA==",
             "dependencies": {
-                "@aws-sdk/types": "^3.973.14",
-                "@aws-sdk/xml-builder": "^3.972.32",
+                "@aws-sdk/types": "^3.973.15",
+                "@aws-sdk/xml-builder": "^3.972.33",
                 "@aws/lambda-invoke-store": "^0.2.2",
-                "@smithy/core": "^3.28.0",
-                "@smithy/signature-v4": "^5.6.0",
-                "@smithy/types": "^4.15.0",
+                "@smithy/core": "^3.29.0",
+                "@smithy/signature-v4": "^5.6.1",
+                "@smithy/types": "^4.15.1",
                 "bowser": "^2.11.0",
                 "tslib": "^2.6.2"
             },
@@ -232,15 +229,14 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-env": {
-            "version": "3.972.51",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.51.tgz",
-            "integrity": "sha512-Xo+/zf5k5pZdo53X8aVXN4MJGfU/M1P7yMM/GbNY/x9fyRZGEzjhKqW38GA0FSQQ9TYKs+bfPyz5ja4bi6pjTQ==",
-            "license": "Apache-2.0",
+            "version": "3.972.52",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.52.tgz",
+            "integrity": "sha512-sxuaHZGHqOgKB8OdL3doXa1NJjqmO60FPfyTnYVKGjX9taRsIEGS9pd+2yALmo06hijZ8L94uSK0kfXZsRmVyA==",
             "dependencies": {
-                "@aws-sdk/core": "^3.974.25",
-                "@aws-sdk/types": "^3.973.14",
-                "@smithy/core": "^3.28.0",
-                "@smithy/types": "^4.15.0",
+                "@aws-sdk/core": "^3.974.26",
+                "@aws-sdk/types": "^3.973.15",
+                "@smithy/core": "^3.29.0",
+                "@smithy/types": "^4.15.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -248,17 +244,16 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-http": {
-            "version": "3.972.53",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.53.tgz",
-            "integrity": "sha512-7E9oFUcf9YWe+ttGiWhe/cCSI+pswwelzgQMoKXgPJi1AIfS27TK6et5ZULqEqHu30zbN+jh1RqlwcXqY/aXyg==",
-            "license": "Apache-2.0",
+            "version": "3.972.54",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.54.tgz",
+            "integrity": "sha512-e6yz52nq3SpR1oPLcvfsDM7H7k2gIYk/NSn/rwsFqzGXEwr3g0mRMlPbLaKCPCGNZJMU/gZg6/64B3eSam+gBw==",
             "dependencies": {
-                "@aws-sdk/core": "^3.974.25",
-                "@aws-sdk/types": "^3.973.14",
-                "@smithy/core": "^3.28.0",
-                "@smithy/fetch-http-handler": "^5.6.1",
-                "@smithy/node-http-handler": "^4.9.1",
-                "@smithy/types": "^4.15.0",
+                "@aws-sdk/core": "^3.974.26",
+                "@aws-sdk/types": "^3.973.15",
+                "@smithy/core": "^3.29.0",
+                "@smithy/fetch-http-handler": "^5.6.2",
+                "@smithy/node-http-handler": "^4.9.2",
+                "@smithy/types": "^4.15.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -266,23 +261,22 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.972.58",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.58.tgz",
-            "integrity": "sha512-MPr0hD8pyDGfF3dWXvFOILhcKTB9ptqJOJK9JEuDQzpc2HgKisY16eR7IrKUXxSbz8LZj+LHz/CS8Y5G1ai7yw==",
-            "license": "Apache-2.0",
+            "version": "3.972.59",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.59.tgz",
+            "integrity": "sha512-9Um/UpruN76AdpiLnvwChVkJJwJ9Vx9ykk/2AeLxxSCM/YYRD8Kkq2towUk9fZQLV7dd9ATlsi87U7hKs0z/iQ==",
             "dependencies": {
-                "@aws-sdk/core": "^3.974.25",
-                "@aws-sdk/credential-provider-env": "^3.972.51",
-                "@aws-sdk/credential-provider-http": "^3.972.53",
-                "@aws-sdk/credential-provider-login": "^3.972.57",
-                "@aws-sdk/credential-provider-process": "^3.972.51",
-                "@aws-sdk/credential-provider-sso": "^3.972.57",
-                "@aws-sdk/credential-provider-web-identity": "^3.972.57",
-                "@aws-sdk/nested-clients": "^3.997.25",
-                "@aws-sdk/types": "^3.973.14",
-                "@smithy/core": "^3.28.0",
-                "@smithy/credential-provider-imds": "^4.4.4",
-                "@smithy/types": "^4.15.0",
+                "@aws-sdk/core": "^3.974.26",
+                "@aws-sdk/credential-provider-env": "^3.972.52",
+                "@aws-sdk/credential-provider-http": "^3.972.54",
+                "@aws-sdk/credential-provider-login": "^3.972.58",
+                "@aws-sdk/credential-provider-process": "^3.972.52",
+                "@aws-sdk/credential-provider-sso": "^3.972.58",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.58",
+                "@aws-sdk/nested-clients": "^3.997.26",
+                "@aws-sdk/types": "^3.973.15",
+                "@smithy/core": "^3.29.0",
+                "@smithy/credential-provider-imds": "^4.4.5",
+                "@smithy/types": "^4.15.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -290,16 +284,15 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-login": {
-            "version": "3.972.57",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.57.tgz",
-            "integrity": "sha512-kPWc/SCrl9agKeywxKwPEoQHanWag0LcNQrcZpEQpjNifkxq6tQENhgrrS9al317CF6yytyihlX+FhPHlk0QjA==",
-            "license": "Apache-2.0",
+            "version": "3.972.58",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.58.tgz",
+            "integrity": "sha512-H3q96qF8/DJsPsXMVtMRqSWOc85K5O4zos32untdw+vE5vw0f3a6qJo1YqbND4BsEIKd4iZmzzVUq9kV4LjbHg==",
             "dependencies": {
-                "@aws-sdk/core": "^3.974.25",
-                "@aws-sdk/nested-clients": "^3.997.25",
-                "@aws-sdk/types": "^3.973.14",
-                "@smithy/core": "^3.28.0",
-                "@smithy/types": "^4.15.0",
+                "@aws-sdk/core": "^3.974.26",
+                "@aws-sdk/nested-clients": "^3.997.26",
+                "@aws-sdk/types": "^3.973.15",
+                "@smithy/core": "^3.29.0",
+                "@smithy/types": "^4.15.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -307,21 +300,20 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.972.60",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.60.tgz",
-            "integrity": "sha512-hE2hIBJQjCDRx8TbSqpVQ+/o2mIrJZQZbQ3LlwE2bJf7z47x5GmhcvGwZPqJH7Oq//SzTXEBGSZ4qSpK3yPbhw==",
-            "license": "Apache-2.0",
+            "version": "3.972.61",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.61.tgz",
+            "integrity": "sha512-2U2KHMRCt1dlZoLU3KZR5g5EL4b0h2HHw96SkaUBK7qvEXPZj5rGRO/3ZTeJmh37dIYQuCnA2273rZOQvmsiHw==",
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "^3.972.51",
-                "@aws-sdk/credential-provider-http": "^3.972.53",
-                "@aws-sdk/credential-provider-ini": "^3.972.58",
-                "@aws-sdk/credential-provider-process": "^3.972.51",
-                "@aws-sdk/credential-provider-sso": "^3.972.57",
-                "@aws-sdk/credential-provider-web-identity": "^3.972.57",
-                "@aws-sdk/types": "^3.973.14",
-                "@smithy/core": "^3.28.0",
-                "@smithy/credential-provider-imds": "^4.4.4",
-                "@smithy/types": "^4.15.0",
+                "@aws-sdk/credential-provider-env": "^3.972.52",
+                "@aws-sdk/credential-provider-http": "^3.972.54",
+                "@aws-sdk/credential-provider-ini": "^3.972.59",
+                "@aws-sdk/credential-provider-process": "^3.972.52",
+                "@aws-sdk/credential-provider-sso": "^3.972.58",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.58",
+                "@aws-sdk/types": "^3.973.15",
+                "@smithy/core": "^3.29.0",
+                "@smithy/credential-provider-imds": "^4.4.5",
+                "@smithy/types": "^4.15.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -329,15 +321,14 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-process": {
-            "version": "3.972.51",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.51.tgz",
-            "integrity": "sha512-081dD2RlnmY+G05v6E73KfACvDjPjnttrLjGHE2SSglbID25UcuijbWpL4g+XR5T2Kl4oIJoVBXi64s+2f009Q==",
-            "license": "Apache-2.0",
+            "version": "3.972.52",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.52.tgz",
+            "integrity": "sha512-Aff9Ebs42lz+Ep1wkS+Nlwh5S0eahakpyskPsuKGjiBJ6ExOjNtxbfKJTKovQtQNgJ7oG1BH6esJwGrbs7qgSA==",
             "dependencies": {
-                "@aws-sdk/core": "^3.974.25",
-                "@aws-sdk/types": "^3.973.14",
-                "@smithy/core": "^3.28.0",
-                "@smithy/types": "^4.15.0",
+                "@aws-sdk/core": "^3.974.26",
+                "@aws-sdk/types": "^3.973.15",
+                "@smithy/core": "^3.29.0",
+                "@smithy/types": "^4.15.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -345,17 +336,16 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.972.57",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.57.tgz",
-            "integrity": "sha512-dC7ZyX3EHKHLOeVUEDzzGvk0L1s6N06YDrau7P0rGXL/j1cO+DzN2w1x9vcEh7zljVCR3019f5mi1Th+GGTURw==",
-            "license": "Apache-2.0",
+            "version": "3.972.58",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.58.tgz",
+            "integrity": "sha512-syloC58mXOacUqM2toPNfwd7X3jT+tWj0F/cN7qdW1FQyI0q41J0tPf6DIZ56BF0x82iS9j3ALP45MoBz79YuQ==",
             "dependencies": {
-                "@aws-sdk/core": "^3.974.25",
-                "@aws-sdk/nested-clients": "^3.997.25",
-                "@aws-sdk/token-providers": "3.1077.0",
-                "@aws-sdk/types": "^3.973.14",
-                "@smithy/core": "^3.28.0",
-                "@smithy/types": "^4.15.0",
+                "@aws-sdk/core": "^3.974.26",
+                "@aws-sdk/nested-clients": "^3.997.26",
+                "@aws-sdk/token-providers": "3.1078.0",
+                "@aws-sdk/types": "^3.973.15",
+                "@smithy/core": "^3.29.0",
+                "@smithy/types": "^4.15.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -363,16 +353,15 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-web-identity": {
-            "version": "3.972.57",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.57.tgz",
-            "integrity": "sha512-HtWM3FV2o7NJFJSUqFLBlxmV9RxQRHpzCvQaP1n1Qo4CxQSvwpJ8ERWHiLqXMFDgDXyELt+EZNFcpG6XQRcJbQ==",
-            "license": "Apache-2.0",
+            "version": "3.972.58",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.58.tgz",
+            "integrity": "sha512-pTBImKzcGK+pcMKjL0fAJbnYzzYd1c0UDc7BSIOGNQhF9Nuk66vWlIXfYTYyzNSs+w8Q/vfbbNDDU8zdrouwLg==",
             "dependencies": {
-                "@aws-sdk/core": "^3.974.25",
-                "@aws-sdk/nested-clients": "^3.997.25",
-                "@aws-sdk/types": "^3.973.14",
-                "@smithy/core": "^3.28.0",
-                "@smithy/types": "^4.15.0",
+                "@aws-sdk/core": "^3.974.26",
+                "@aws-sdk/nested-clients": "^3.997.26",
+                "@aws-sdk/types": "^3.973.15",
+                "@smithy/core": "^3.29.0",
+                "@smithy/types": "^4.15.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -380,16 +369,15 @@
             }
         },
         "node_modules/@aws-sdk/middleware-sdk-s3": {
-            "version": "3.972.56",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.56.tgz",
-            "integrity": "sha512-VFLd7bT8ef48H2n2iDrY/w9EPpXLmC0v4NEriXy2vuTgEP/FrKqrcwi7eobhcOrdO37uLbMt5AWZlY55R2/xqg==",
-            "license": "Apache-2.0",
+            "version": "3.972.57",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.57.tgz",
+            "integrity": "sha512-E7tRmmUb64LlsoI6pZZRTov21K74Fr/MVgYBeNFfBkFzpF8e2tuJkKd4YGmcNwz0UjDs8fMoS0v/MGgHASIx+Q==",
             "dependencies": {
-                "@aws-sdk/core": "^3.974.25",
-                "@aws-sdk/signature-v4-multi-region": "^3.996.37",
-                "@aws-sdk/types": "^3.973.14",
-                "@smithy/core": "^3.28.0",
-                "@smithy/types": "^4.15.0",
+                "@aws-sdk/core": "^3.974.26",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.38",
+                "@aws-sdk/types": "^3.973.15",
+                "@smithy/core": "^3.29.0",
+                "@smithy/types": "^4.15.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -397,18 +385,17 @@
             }
         },
         "node_modules/@aws-sdk/nested-clients": {
-            "version": "3.997.25",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.25.tgz",
-            "integrity": "sha512-VpRQ3wR6l+fwRHV5veJL2ehtyQFrGyH/2CJG9DVtb8H3xyqqnZWSTSrq/CJJ7DvDlDgrPRiW2SkYA8pN6VWCFQ==",
-            "license": "Apache-2.0",
+            "version": "3.997.26",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.26.tgz",
+            "integrity": "sha512-Lwe3F6K7bs+jEubp1LbrvzeMBYb5fMazJ1IxV9TtKWPF8CSh67Fmwyq9fLz3NL/k55Dfpuph5Dimw76JFgr+SA==",
             "dependencies": {
-                "@aws-sdk/core": "^3.974.25",
-                "@aws-sdk/signature-v4-multi-region": "^3.996.37",
-                "@aws-sdk/types": "^3.973.14",
-                "@smithy/core": "^3.28.0",
-                "@smithy/fetch-http-handler": "^5.6.1",
-                "@smithy/node-http-handler": "^4.9.1",
-                "@smithy/types": "^4.15.0",
+                "@aws-sdk/core": "^3.974.26",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.38",
+                "@aws-sdk/types": "^3.973.15",
+                "@smithy/core": "^3.29.0",
+                "@smithy/fetch-http-handler": "^5.6.2",
+                "@smithy/node-http-handler": "^4.9.2",
+                "@smithy/types": "^4.15.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -416,16 +403,15 @@
             }
         },
         "node_modules/@aws-sdk/s3-request-presigner": {
-            "version": "3.1077.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1077.0.tgz",
-            "integrity": "sha512-gmj0nvnnuLDvXHekQNCTljcp/0XrQ1Mi6EpFYv6TF/u9oa4PugIhO5BpIDoKf4qvaQuOX+71E8KMkn9GS75dPw==",
-            "license": "Apache-2.0",
+            "version": "3.1078.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1078.0.tgz",
+            "integrity": "sha512-paQ3KW+VVHptNvNA+qRRlSO6pU9BaiF83M9Ax8NeTEsZHG3Gd83/Z/Ym1/5kDt8xgCNUTeyrrJWx/ony2YrLYg==",
             "dependencies": {
-                "@aws-sdk/core": "^3.974.25",
-                "@aws-sdk/signature-v4-multi-region": "^3.996.37",
-                "@aws-sdk/types": "^3.973.14",
-                "@smithy/core": "^3.28.0",
-                "@smithy/types": "^4.15.0",
+                "@aws-sdk/core": "^3.974.26",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.38",
+                "@aws-sdk/types": "^3.973.15",
+                "@smithy/core": "^3.29.0",
+                "@smithy/types": "^4.15.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -433,14 +419,13 @@
             }
         },
         "node_modules/@aws-sdk/signature-v4-multi-region": {
-            "version": "3.996.37",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.37.tgz",
-            "integrity": "sha512-u8qd064XsHzM0Mk+yH4IPKn/ZC9rdniEKs+neBHNlsPZirw3rcLvmrH4ImoKC4yF7A0I/MbcC3dseARnJLiAhg==",
-            "license": "Apache-2.0",
+            "version": "3.996.38",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.38.tgz",
+            "integrity": "sha512-C379Sk+MiFZCfWZphKlMyLHKxV22OjoGM5KJjj5IJNJcOCWL4IGIpnEGzv1FQiRwhYXfq55SJMfxlqPE08JJ9g==",
             "dependencies": {
-                "@aws-sdk/types": "^3.973.14",
-                "@smithy/signature-v4": "^5.6.0",
-                "@smithy/types": "^4.15.0",
+                "@aws-sdk/types": "^3.973.15",
+                "@smithy/signature-v4": "^5.6.1",
+                "@smithy/types": "^4.15.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -448,16 +433,15 @@
             }
         },
         "node_modules/@aws-sdk/token-providers": {
-            "version": "3.1077.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1077.0.tgz",
-            "integrity": "sha512-sRUkfZ3fpOco95jZHsQUQiXvuIVLvCmWVclFg6dRFDyfsYs6Pdr/NuZ2+yJxeHN+6WAfDh2aZ8nlZntnvuhZUQ==",
-            "license": "Apache-2.0",
+            "version": "3.1078.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1078.0.tgz",
+            "integrity": "sha512-/uyXLBGu3Lw1GbBA2X66hcOMnKtMcqAIF+3/eHfxBQmUeXF2sdqozDPrTfEr/TnSd0D6deZar+eVyhEqqWu29w==",
             "dependencies": {
-                "@aws-sdk/core": "^3.974.25",
-                "@aws-sdk/nested-clients": "^3.997.25",
-                "@aws-sdk/types": "^3.973.14",
-                "@smithy/core": "^3.28.0",
-                "@smithy/types": "^4.15.0",
+                "@aws-sdk/core": "^3.974.26",
+                "@aws-sdk/nested-clients": "^3.997.26",
+                "@aws-sdk/types": "^3.973.15",
+                "@smithy/core": "^3.29.0",
+                "@smithy/types": "^4.15.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -465,11 +449,11 @@
             }
         },
         "node_modules/@aws-sdk/types": {
-            "version": "3.973.14",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.14.tgz",
-            "integrity": "sha512-vH4pEu9YBEwr67yT+GVcmKX0GzfIrIYUn+MF5vXg9OspouVnAekuyVyawFvZHEK7WlcwVDwNrqI3ZBDUAiyu9A==",
+            "version": "3.973.15",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.15.tgz",
+            "integrity": "sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ==",
             "dependencies": {
-                "@smithy/types": "^4.15.0",
+                "@smithy/types": "^4.15.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -477,12 +461,11 @@
             }
         },
         "node_modules/@aws-sdk/xml-builder": {
-            "version": "3.972.32",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.32.tgz",
-            "integrity": "sha512-2loKuOMRFDg1nwdni5AtJ9S5juVbRNPNsPC7tWTfkHyycPwACMhxepspUHi8GhvfNlL2cQo3sPMod1uib+KZ0w==",
-            "license": "Apache-2.0",
+            "version": "3.972.33",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.33.tgz",
+            "integrity": "sha512-ezbwz9WpuLctm6o7P2t2naDhVVPI5jFGrVefVybhcKGjU57VIyT46pQVO0RI2RYkUdhdj2Z9uSIlAzGZE9NW9A==",
             "dependencies": {
-                "@smithy/types": "^4.15.0",
+                "@smithy/types": "^4.15.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2443,9 +2426,9 @@
             }
         },
         "node_modules/@next/env": {
-            "version": "16.2.9",
-            "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.9.tgz",
-            "integrity": "sha512-ki5VxxXfzD/9TDe13wyeTKIjQTAwBVpnr8KhRDUr8ltMUq1/NBpWNT5tiPoxiGl+PHM4X2ahSOiPk6iAimIzPg=="
+            "version": "16.2.10",
+            "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.10.tgz",
+            "integrity": "sha512-zLPxg9M0MEHmygpj5OuxjQ+vHMiy/K7cSp74G8ecYolmgUWw0RwN02tF56npup/+qaI8JB97hQgS/r2Hb6QwVA=="
         },
         "node_modules/@next/eslint-plugin-next": {
             "version": "13.5.11",
@@ -2479,9 +2462,9 @@
             }
         },
         "node_modules/@next/swc-darwin-arm64": {
-            "version": "16.2.9",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.9.tgz",
-            "integrity": "sha512-HkfxNYUCmcct0Xsqib5KxqMSHV4AHJq857BNRchyBDs4YS19aHzVfn1kDuBYKqLLQBjXgnkIsjV2Kd4d2wzYhw==",
+            "version": "16.2.10",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.10.tgz",
+            "integrity": "sha512-v9IdJCa0H0mbo+8z5zwUpOk1Vj7RjkcI5uNYf5Ws1y6szf/p3Mzl9hLaST8SCt6L9h8NGnruZcd2+o0NTNwDhA==",
             "cpu": [
                 "arm64"
             ],
@@ -2494,9 +2477,9 @@
             }
         },
         "node_modules/@next/swc-darwin-x64": {
-            "version": "16.2.9",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.9.tgz",
-            "integrity": "sha512-7IAtK4MeybpqRV9GRABWEhJ62mOS+rzWOzOTFie4cSEtm12xsoOMJRcECoZx3FHPzFAqN/IJtHqWAFOLfl152w==",
+            "version": "16.2.10",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.10.tgz",
+            "integrity": "sha512-17IS0jJRViROGmA9uGdNR8VPJpfbnaVG7E9qhso5jDLkmyd0lSDORWxbcKINzcFqzZqGwGtMSnrFRxBpuUYjLQ==",
             "cpu": [
                 "x64"
             ],
@@ -2509,9 +2492,9 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-gnu": {
-            "version": "16.2.9",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.9.tgz",
-            "integrity": "sha512-hBD75iWpUtkL9SmQmcRhmLomn9jgkPzCEkbOcLgHymPEKzv+6ONy13RRiIEz/iEObjkS2Jlb5gYS2XGoS3X4rw==",
+            "version": "16.2.10",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.10.tgz",
+            "integrity": "sha512-GRQRsRtuciNJvB54AvvuQTiq0oZtFwa1owQqtZD8wwnGpM2L39MV22kpI72YSXLKIyY40LC66EiLFv4PiicXxg==",
             "cpu": [
                 "arm64"
             ],
@@ -2524,9 +2507,9 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-musl": {
-            "version": "16.2.9",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.9.tgz",
-            "integrity": "sha512-qZTI3pf9SGc/obr8NkQAekBxmp1QK+kVm+VAf3BALLfFAj+1kUhkTxmrWpVos9R/UYIA8AWX2p6cGI5WdwzVUA==",
+            "version": "16.2.10",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.10.tgz",
+            "integrity": "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==",
             "cpu": [
                 "arm64"
             ],
@@ -2539,9 +2522,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-gnu": {
-            "version": "16.2.9",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.9.tgz",
-            "integrity": "sha512-xm0HfRNX+UkH4R3c18ynswjj5o5uEj/7iI9p9omdtTSIsRCzQqkGMA+10nzJ4EHnYC3as65IMhbbl5fWRUWHYg==",
+            "version": "16.2.10",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.10.tgz",
+            "integrity": "sha512-iCVJnwvrPYECvA6WM/7+oo+OiTvedIKLxtCLAZP4xZR3nXa1zmzZyLPbYCmWvpd4CvMYF1EMTafd0ii3DygLvA==",
             "cpu": [
                 "x64"
             ],
@@ -2554,9 +2537,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-musl": {
-            "version": "16.2.9",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.9.tgz",
-            "integrity": "sha512-QumimHkGEG6vM3PfEDWKyKen03NcqLOkeKB1EfcPe7VxzmEiCa4jNnMyBn/US5zcd/VE1CI+O8Ovb3lfjVHfGw==",
+            "version": "16.2.10",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.10.tgz",
+            "integrity": "sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==",
             "cpu": [
                 "x64"
             ],
@@ -2569,9 +2552,9 @@
             }
         },
         "node_modules/@next/swc-win32-arm64-msvc": {
-            "version": "16.2.9",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.9.tgz",
-            "integrity": "sha512-hzQpKZvw8rAwI6A2uQh6SacCSvNAXaIkPNsWwzqqfRiIMiXMfH936skDhz1OO6KpvdKkJrgHHtqQOq5PIXOvdQ==",
+            "version": "16.2.10",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.10.tgz",
+            "integrity": "sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA==",
             "cpu": [
                 "arm64"
             ],
@@ -2584,9 +2567,9 @@
             }
         },
         "node_modules/@next/swc-win32-x64-msvc": {
-            "version": "16.2.9",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.9.tgz",
-            "integrity": "sha512-qr2VL3Ce5QrwgO2yh1ujSBawrimjVKX8FGF/cOynmdYKJY0BdHpGVNIRK1tqONB10Vkm25Ub1BD2bkjWs4+96w==",
+            "version": "16.2.10",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.10.tgz",
+            "integrity": "sha512-0JXq3b85Jk9Jg4ntLUbXSPvoDw3gpZou7twuKdoFG2jOw635v7+IiXfTaa0TxVMyx78pUjnrVYwLgjKfX4e6/A==",
             "cpu": [
                 "x64"
             ],
@@ -5328,11 +5311,11 @@
             }
         },
         "node_modules/@smithy/core": {
-            "version": "3.28.0",
-            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.28.0.tgz",
-            "integrity": "sha512-N/LoLG8pZ1zv5cIWpdF6vmSjtZtXKK9G0OqT5yYCOZU+CzPq1+nYA95VoKJBGWRScs7YbMugZ7lZx8Fj1vdHoA==",
+            "version": "3.29.0",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.0.tgz",
+            "integrity": "sha512-sEvpvkBVoMxjoek35XyJFn2ZD3EJ1RpiZrT47WaZodxzAIWS44zkdvbqGE/ZlugtjiQp62cffYZ9ldyRkjAGnA==",
             "dependencies": {
-                "@smithy/types": "^4.15.0",
+                "@smithy/types": "^4.15.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -5340,13 +5323,12 @@
             }
         },
         "node_modules/@smithy/credential-provider-imds": {
-            "version": "4.4.4",
-            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.4.tgz",
-            "integrity": "sha512-jT0WrDaM88L5na9FX1xRNywCS3B1n75wPY5Ksasjo0PHUtuI7d8FclksN1BbOSYTiaiKxUDqU23nUymH/V+AaQ==",
-            "license": "Apache-2.0",
+            "version": "4.4.5",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.5.tgz",
+            "integrity": "sha512-LnjUTNG0GgQlKIq7IioeOrPaEmC5xOd1WtAz24TLSiYQnWX2uHr53GrFuQhkrJBktPYCMga/NbUOW7hFbSA2Cg==",
             "dependencies": {
-                "@smithy/core": "^3.28.0",
-                "@smithy/types": "^4.15.0",
+                "@smithy/core": "^3.29.0",
+                "@smithy/types": "^4.15.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -5354,13 +5336,12 @@
             }
         },
         "node_modules/@smithy/fetch-http-handler": {
-            "version": "5.6.1",
-            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.1.tgz",
-            "integrity": "sha512-fW6l9rWoyk1iyzfuZaERnZLNjB6WIojgGm6Bo9Hpfpy3RUpltjLikNlxTsS/YtxVobcfbCGBuAncREYqT4hvqQ==",
-            "license": "Apache-2.0",
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.2.tgz",
+            "integrity": "sha512-q96PSDOAGw+X+nuELd7Cjebps0SYr+YlPbviEX9sLVw+VM4M7VV8hn1nL1mGS6urDu33eQ5A7WhlphaDO6kUyQ==",
             "dependencies": {
-                "@smithy/core": "^3.28.0",
-                "@smithy/types": "^4.15.0",
+                "@smithy/core": "^3.29.0",
+                "@smithy/types": "^4.15.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -5368,13 +5349,12 @@
             }
         },
         "node_modules/@smithy/node-http-handler": {
-            "version": "4.9.1",
-            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.1.tgz",
-            "integrity": "sha512-m/f15di58P6NtLQ7eVEb5N19NdJWn+4c7zfkFHMT/i3JH7U8UtknpPoy8o2tm2R3OdliYvsvQhZHIfACQDqT+Q==",
-            "license": "Apache-2.0",
+            "version": "4.9.2",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.2.tgz",
+            "integrity": "sha512-s0yAIRj6TVfHgl+QzVyqal1KMGZ9B5512IrxKc6+dOpw8fUmFL3CvuAhjv0J+aNjUPfVZ2IhqPEDvkB5Ncx9oA==",
             "dependencies": {
-                "@smithy/core": "^3.28.0",
-                "@smithy/types": "^4.15.0",
+                "@smithy/core": "^3.29.0",
+                "@smithy/types": "^4.15.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -5382,13 +5362,12 @@
             }
         },
         "node_modules/@smithy/signature-v4": {
-            "version": "5.6.0",
-            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.0.tgz",
-            "integrity": "sha512-IkPHQdbyoebSwBCuMTzJ/2oIhKVqiZZAZxQYSlpDZqq/WhJUpmdgbHvP7ItddxsPzcDUJeI0V4PNMSNtlZ0aqA==",
-            "license": "Apache-2.0",
+            "version": "5.6.1",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.1.tgz",
+            "integrity": "sha512-SqvuP75p/DmgWWI7jv4kf/UW+V4LFmlUn19s604SgAcRuJRB1vDnWwzZMYCLUcmKxko9wDn6iLgGEIpTNgZbIQ==",
             "dependencies": {
-                "@smithy/core": "^3.28.0",
-                "@smithy/types": "^4.15.0",
+                "@smithy/core": "^3.29.0",
+                "@smithy/types": "^4.15.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -5396,9 +5375,9 @@
             }
         },
         "node_modules/@smithy/types": {
-            "version": "4.15.0",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
-            "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
+            "version": "4.15.1",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.1.tgz",
+            "integrity": "sha512-x3L0XSACF6UYzKpa9biqiRMgvH5+wnFFew9Tm/grFYqgaupPwx/+ojDPpPJM8dZON3S9tjz5U+PQYsCBd1Mw5Q==",
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -16630,11 +16609,11 @@
             }
         },
         "node_modules/next": {
-            "version": "16.2.9",
-            "resolved": "https://registry.npmjs.org/next/-/next-16.2.9.tgz",
-            "integrity": "sha512-MEOJiq/UvuezAdqVSceHbqDgZt1kDw2tpGVOlsdIoJsQdbN2JY2hpVG4xnXGkbdJUOEWhnRfiu/O4Hpc9Juwww==",
+            "version": "16.2.10",
+            "resolved": "https://registry.npmjs.org/next/-/next-16.2.10.tgz",
+            "integrity": "sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA==",
             "dependencies": {
-                "@next/env": "16.2.9",
+                "@next/env": "16.2.10",
                 "@swc/helpers": "0.5.15",
                 "baseline-browser-mapping": "^2.9.19",
                 "caniuse-lite": "^1.0.30001579",
@@ -16648,14 +16627,14 @@
                 "node": ">=20.9.0"
             },
             "optionalDependencies": {
-                "@next/swc-darwin-arm64": "16.2.9",
-                "@next/swc-darwin-x64": "16.2.9",
-                "@next/swc-linux-arm64-gnu": "16.2.9",
-                "@next/swc-linux-arm64-musl": "16.2.9",
-                "@next/swc-linux-x64-gnu": "16.2.9",
-                "@next/swc-linux-x64-musl": "16.2.9",
-                "@next/swc-win32-arm64-msvc": "16.2.9",
-                "@next/swc-win32-x64-msvc": "16.2.9",
+                "@next/swc-darwin-arm64": "16.2.10",
+                "@next/swc-darwin-x64": "16.2.10",
+                "@next/swc-linux-arm64-gnu": "16.2.10",
+                "@next/swc-linux-arm64-musl": "16.2.10",
+                "@next/swc-linux-x64-gnu": "16.2.10",
+                "@next/swc-linux-x64-musl": "16.2.10",
+                "@next/swc-win32-arm64-msvc": "16.2.10",
+                "@next/swc-win32-x64-msvc": "16.2.10",
                 "sharp": "^0.34.5"
             },
             "peerDependencies": {

--- a/migration/requirements.txt
+++ b/migration/requirements.txt
@@ -1,6 +1,6 @@
 # pkg_resources required by ckanapi - must be installed first
 setuptools>=78.1.1
-prefect>=3.0,<4
+prefect>=3.7.6,<4
 pathlib==1.0.1
 semver==3.0.4
 pydantic>=2.13.4,<3

--- a/migration/requirements.txt
+++ b/migration/requirements.txt
@@ -11,7 +11,7 @@ python-dotenv==1.2.2
 psycopg2-binary==2.9.12
 boto3==1.34.35
 pandas==2.3.3
-openpyxl==3.1.2
+openpyxl==3.1.5
 lxml==6.1.1
 pycountry==22.3.5
 ckanapi==4.11

--- a/migration/requirements.txt
+++ b/migration/requirements.txt
@@ -17,5 +17,5 @@ pycountry==22.3.5
 ckanapi==4.11
 markdown==3.10.2
 urllib3>=2.7.0 # not directly required, pinned by Snyk to avoid a vulnerability
-requests>=2.32.4 # not directly required, pinned by Snyk to avoid a vulnerability
+requests>=2.34.2 # not directly required, pinned by Snyk to avoid a vulnerability
 

--- a/migration/requirements.txt
+++ b/migration/requirements.txt
@@ -6,7 +6,7 @@ semver==3.0.4
 pydantic>=2.13.4,<3
 datasize==1.0.0
 python-dateutil==2.9.0.post0
-pytz==2023.3.post1
+pytz==2023.4
 python-dotenv==1.2.2
 psycopg2-binary==2.9.12
 boto3==1.34.35

--- a/migration/requirements.txt
+++ b/migration/requirements.txt
@@ -9,7 +9,7 @@ python-dateutil==2.9.0.post0
 pytz==2023.3.post1
 python-dotenv==1.2.2
 psycopg2-binary==2.9.12
-boto3==1.34.35
+boto3==1.43.39
 pandas==2.3.3
 openpyxl==3.1.2
 lxml==6.1.1

--- a/scripts/cost-splitting/poetry.lock
+++ b/scripts/cost-splitting/poetry.lock
@@ -2,18 +2,18 @@
 
 [[package]]
 name = "boto3"
-version = "1.43.38"
+version = "1.43.39"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "boto3-1.43.38-py3-none-any.whl", hash = "sha256:edffb4a8f49c0a61e8f4aa4104cc2da3c362de8042fc0819216d5e5ce5d38380"},
-    {file = "boto3-1.43.38.tar.gz", hash = "sha256:a8d1e175a87a743e755237d884d7e5f4606e61e5602e9823469a1a630e379b3c"},
+    {file = "boto3-1.43.39-py3-none-any.whl", hash = "sha256:f4eef8bf98559342466a9a1a063b7efcf3e337e98a819479bc2f7a603b8b8ba7"},
+    {file = "boto3-1.43.39.tar.gz", hash = "sha256:ca5701ddf1215ba25b9d973d18505bb4def3a75d3daa9b263c6d8c713b601cb3"},
 ]
 
 [package.dependencies]
-botocore = ">=1.43.38,<1.44.0"
+botocore = ">=1.43.39,<1.44.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.19.0,<0.20.0"
 
@@ -22,14 +22,14 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.43.38"
+version = "1.43.39"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "botocore-1.43.38-py3-none-any.whl", hash = "sha256:54c1c41aff82422d2b88a8a7d782fde8ae1299a45f088d00011d85c4bc44b0cc"},
-    {file = "botocore-1.43.38.tar.gz", hash = "sha256:70fbd5c74f5742f5975ddcc61e6afb5174cb80577c2ccc17c6898ad3a49b51f3"},
+    {file = "botocore-1.43.39-py3-none-any.whl", hash = "sha256:7cd5fab9d33f487777e2c508573bca6ae230779230263d47a617f4af960d3003"},
+    {file = "botocore-1.43.39.tar.gz", hash = "sha256:a95b90ea13aca409d79cc90d87c75df7db1a104a4c8e93707b62a3593bfdd17d"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
## Summary

Batch merge of all open Dependabot PRs (#955–#965) into a single branch for review and CI.

| Area | Updates |
|---|---|
| **deployment/frontend** | npm-minor-patch group (3 packages) — `package-lock.json` |
| **migration** | boto3 1.43.39, prefect ≥3.7.6, requests ≥2.34.2, pytz 2023.4, openpyxl 3.1.5 |
| **datapusher** | boto3 1.43.39, python-dotenv 1.2.2, lxml 6.1.1 |
| **ckanext-wri** | numpy ≥1.26.4,<2.0.0 |
| **scripts/cost-splitting** | boto3 1.43.39 (+ `poetry.lock`) |

## Merged Dependabot PRs

- #965 — npm-minor-patch group in `/deployment/frontend`
- #964 — pytz 2023.4 in `/migration`
- #963 — openpyxl 3.1.5 in `/migration`
- #962 — boto3 1.43.39 in `/datapusher`
- #961 — requests ≥2.34.2 in `/migration`
- #960 — prefect ≥3.7.6,<4 in `/migration`
- #959 — boto3 1.43.39 in `/scripts/cost-splitting`
- #958 — numpy ≥1.26.4,<2.0.0 in `/ckan-backend-dev/src/ckanext-wri`
- #957 — python-dotenv 1.2.2 in `/datapusher`
- #956 — lxml 6.1.1 in `/datapusher`
- #955 — boto3 1.43.39 in `/migration`

## Files changed

- `deployment/frontend/package-lock.json`
- `migration/requirements.txt`
- `datapusher/requirements.txt`
- `ckan-backend-dev/src/ckanext-wri/requirements.txt`
- `scripts/cost-splitting/poetry.lock`

## Test plan

- [ ] CI build and test jobs pass (CKAN, datapusher, migration, frontend)
- [ ] `test-report` (cost-splitting) passes — `poetry install` verified locally with updated lock file
- [ ] Close individual Dependabot PRs #955–#965 after merge