### PR TITLE
feat: loading time optimization on loading dashboard

### DIFF
--- a/ckan-backend-dev/src/ckanext-wri/ckanext/wri/logic/action/get.py
+++ b/ckan-backend-dev/src/ckanext-wri/ckanext/wri/logic/action/get.py
@@ -559,11 +559,24 @@ def notification_get_all(
         )
         return {"count": unread_count}
 
+    try:
+        limit = int(data_dict.get("limit", 0))
+    except (TypeError, ValueError):
+        limit = 0
+
     sender_obj = {}
     object_data = {}
     valid_notifications = []
 
     for notification in notification_objecst_result:
+        if limit > 0 and len(valid_notifications) >= limit:
+            break
+
+        # The frontend never renders deleted notifications, so skip the
+        # enrichment work (and payload) for them.
+        if notification.get("state") == "deleted":
+            continue
+
         sender_id = notification["sender_id"]
         object_id = notification["object_id"]
         if sender_id in sender_obj:

--- a/ckan-backend-dev/src/ckanext-wri/ckanext/wri/logic/action/get.py
+++ b/ckan-backend-dev/src/ckanext-wri/ckanext/wri/logic/action/get.py
@@ -549,7 +549,15 @@ def notification_get_all(
         )
 
     if not notification_objecst_result:
-        return []
+        return [] if not asbool(data_dict.get("count_only")) else {"count": 0}
+
+    if asbool(data_dict.get("count_only")):
+        unread_count = sum(
+            1
+            for notification in notification_objecst_result
+            if notification.get("is_unread") and notification.get("state") != "deleted"
+        )
+        return {"count": unread_count}
 
     sender_obj = {}
     object_data = {}

--- a/ckan-backend-dev/src/ckanext-wri/ckanext/wri/logic/auth/schema.py
+++ b/ckan-backend-dev/src/ckanext-wri/ckanext/wri/logic/auth/schema.py
@@ -130,7 +130,8 @@ def default_get_notification_schema(
         "object_id": [ignore_empty, ignore_missing],
         "time_sent": [ignore_empty, ignore_missing],
         "is_unread":[ignore_empty, ignore_missing],
-        "state": [ignore_empty, ignore_missing]
+        "state": [ignore_empty, ignore_missing],
+        "count_only": [ignore_empty, ignore_missing],
     }
 
 @validator_args

--- a/ckan-backend-dev/src/ckanext-wri/ckanext/wri/logic/auth/schema.py
+++ b/ckan-backend-dev/src/ckanext-wri/ckanext/wri/logic/auth/schema.py
@@ -132,6 +132,7 @@ def default_get_notification_schema(
         "is_unread":[ignore_empty, ignore_missing],
         "state": [ignore_empty, ignore_missing],
         "count_only": [ignore_empty, ignore_missing],
+        "limit": [ignore_empty, ignore_missing],
     }
 
 @validator_args

--- a/ckan-backend-dev/src/ckanext-wri/ckanext/wri/model/notification.py
+++ b/ckan-backend-dev/src/ckanext-wri/ckanext/wri/model/notification.py
@@ -85,7 +85,7 @@ class Notification(object):
             if recipient_id:
                 query = query.filter(Notification.recipient_id == recipient_id)
 
-            return query.all()
+            return query.order_by(Notification.time_sent.desc()).all()
     
     @classmethod
     def update(

--- a/deployment/frontend/src/components/_shared/Header.tsx
+++ b/deployment/frontend/src/components/_shared/Header.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useEffect, useState } from 'react';
+import React, { Fragment, useState } from 'react';
 import Image from 'next/image';
 import { Menu, Transition, Dialog } from '@headlessui/react';
 import { Bars3Icon } from '@heroicons/react/20/solid';
@@ -17,16 +17,10 @@ export default function Header() {
     const apiTokenQuery = api.auth.getApiTokensList.useQuery(
         {},
         {
-            enabled: false,
-            cacheTime: 1,
+            enabled: session.status === 'authenticated',
+            staleTime: 5 * 60 * 1000,
         }
     );
-
-    useEffect(() => {
-        if (session.status == 'authenticated') {
-            apiTokenQuery.refetch();
-        }
-    }, [session?.status]);
 
     function closeModal() {
         setIsOpen(false);

--- a/deployment/frontend/src/components/_shared/Header.tsx
+++ b/deployment/frontend/src/components/_shared/Header.tsx
@@ -14,7 +14,7 @@ export default function Header() {
     const [isOpen, setIsOpen] = useState(false);
     const session = useSession();
 
-    const apiTokenQuery = api.auth.getApiTokensList.useQuery(
+    api.auth.getApiTokensList.useQuery(
         {},
         {
             enabled: session.status === 'authenticated',

--- a/deployment/frontend/src/components/_shared/PendingApprovalTag.tsx
+++ b/deployment/frontend/src/components/_shared/PendingApprovalTag.tsx
@@ -15,7 +15,7 @@ function StatusChip({ status }: { status?: string }) {
 export default function PendingApprovalTag({
   dataset
 }: {
-  dataset: WriDataset
+  dataset: Pick<WriDataset, 'creator_user_id' | 'approval_status' | 'owner_org'>
 }) {
   const session = useSession();
   const userCapacity = api.user.getUserCapacity.useQuery(undefined, {

--- a/deployment/frontend/src/components/dashboard/Favourites.tsx
+++ b/deployment/frontend/src/components/dashboard/Favourites.tsx
@@ -9,9 +9,21 @@ import { api } from '@/utils/api';
 import type { WriDataset } from '@/schema/ckan.schema';
 import { formatDate } from '@/utils/general';
 import PendingApprovalTag from '../_shared/PendingApprovalTag';
+import Spinner from '../_shared/Spinner';
 
-function Favourite({ dataset }: { dataset: WriDataset }) {
-    const created = dataset?.metadata_modified ? dataset.metadata_modified : '';
+type FavouriteDatasetPreview = Pick<
+    WriDataset,
+    | 'id'
+    | 'name'
+    | 'title'
+    | 'metadata_modified'
+    | 'creator_user_id'
+    | 'approval_status'
+    | 'owner_org'
+>;
+
+function Favourite({ dataset }: { dataset: FavouriteDatasetPreview }) {
+    const created = dataset?.metadata_modified ?? '';
     return (
         <div className="flex flex-col hover:bg-slate-100 px-3 pb-2 pt-2 mb-2 pb-2 rounded-md">
             <div className="flex items-center gap-x-2">
@@ -30,7 +42,9 @@ function Favourite({ dataset }: { dataset: WriDataset }) {
     );
 }
 export default function Favourites({ drag }: { drag: boolean }) {
-    const { data, isLoading } = api.dataset.getFavoriteDataset.useQuery();
+    const { data, isLoading } = api.dataset.getFavoriteDataset.useQuery({
+        preview: true,
+    });
     return (
         <section
             id="favourites"
@@ -55,12 +69,14 @@ export default function Favourites({ drag }: { drag: boolean }) {
                     <ArrowRightIcon className="w-4 h-4 mb-1" />
                 </Link>
             </div>
-            {data?.datasets.length === 0 ? (
+            {isLoading ? (
+                <Spinner className="mx-auto" />
+            ) : data?.datasets.length === 0 ? (
                 <div className="flex justify-center items-center h-screen">
                     No data
                 </div>
             ) : (
-                data?.datasets.slice(0, 10).map((items, index) => {
+                data?.datasets.map((items, index) => {
                     return <Favourite key={index} dataset={items} />;
                 })
             )}

--- a/deployment/frontend/src/components/dashboard/Layout.tsx
+++ b/deployment/frontend/src/components/dashboard/Layout.tsx
@@ -17,7 +17,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
     const { data: pendingData, isLoading: isLoadingPending } =
         api.dataset.getPendingDatasets.useQuery({
             search: '',
-            page: { start: 0, rows: 100 },
+            page: { start: 0, rows: 0 },
             sortBy: 'metadata_modified desc',
         });
     const { data: userIdentity, isLoading: isLoadingIUser } =
@@ -230,14 +230,10 @@ export default function Layout({ children }: { children: React.ReactNode }) {
                                                                                     }
                                                                                     {isLoadingPending ? (
                                                                                         <Spinner className="w-2 h-2" />
-                                                                                    ) : pendingData
-                                                                                          ?.datasets
-                                                                                          ?.length ? (
+                                                                                    ) : pendingData?.count ? (
                                                                                         <div className="text-[0.688rem] font-semibold bg-wri-gold text-black  flex justify-center items-center w-5 h-5 rounded-full pt-1">
                                                                                             {
-                                                                                                pendingData
-                                                                                                    ?.datasets
-                                                                                                    .length
+                                                                                                pendingData.count
                                                                                             }
                                                                                         </div>
                                                                                     ) : (
@@ -371,14 +367,10 @@ export default function Layout({ children }: { children: React.ReactNode }) {
                                                                             </div>
                                                                             {isLoadingPending ? (
                                                                                 <Spinner className="w-2 h-2" />
-                                                                            ) : pendingData
-                                                                                  ?.datasets
-                                                                                  ?.length ? (
+                                                                            ) : pendingData?.count ? (
                                                                                 <div className="text-[0.688rem] font-semibold bg-wri-gold text-black  flex justify-center items-center w-5 h-5 rounded-full pt-1">
                                                                                     {
-                                                                                        pendingData
-                                                                                            ?.datasets
-                                                                                            .length
+                                                                                        pendingData.count
                                                                                     }
                                                                                 </div>
                                                                             ) : (

--- a/deployment/frontend/src/components/dashboard/Notifications.tsx
+++ b/deployment/frontend/src/components/dashboard/Notifications.tsx
@@ -68,11 +68,19 @@ function Notification({ items }: { items: NotificationType }) {
     );
 }
 export default function Notifications({ drag }: { drag: boolean }) {
+    const { data: countData, isLoading: isLoadingCount } =
+        api.notification.getAllNotifications.useQuery({});
     const { data, isLoading } = api.notification.getAllNotifications.useQuery({
         returnLength: true,
+        limit: 6,
     });
 
-    if (isLoading) return <Spinner className="mx-auto" />;
+    const isLoadingAny = isLoading || isLoadingCount;
+    const notificationCount = countData
+        ? (countData as { count: number }).count
+        : 0;
+
+    if (isLoadingAny) return <Spinner className="mx-auto" />;
 
     return (
         <section
@@ -93,22 +101,14 @@ export default function Notifications({ drag }: { drag: boolean }) {
             <div className="flex px-2 mb-6 pb-2 border-b-[0.3px] border-b-gray-100">
                 <div className="flex gap-x-2">
                     <p className="font-normal text-[20px]">Notifications </p>
-                    {isLoading ? (
+                    {isLoadingAny ? (
                         <Spinner className="w-2 h-2" />
-                    ) : (data as NotificationType[])?.length ? (
+                    ) : notificationCount ? (
                         <DefaultTooltip
-                            content={`${
-                                (data as NotificationType[]).filter(
-                                    (item) => item.is_unread
-                                ).length
-                            } unread`}
+                            content={`${notificationCount} unread`}
                         >
                             <div className="rounded-full my-auto w-4 h-4 bg-wri-gold font-bold text-[11px] flex justify-center items-center">
-                                {
-                                    (data as NotificationType[]).filter(
-                                        (item) => item.is_unread
-                                    ).length
-                                }
+                                {notificationCount}
                             </div>
                         </DefaultTooltip>
                     ) : (
@@ -124,7 +124,7 @@ export default function Notifications({ drag }: { drag: boolean }) {
                 </Link>
             </div>
             {(data as NotificationType[])?.length
-                ? (data as NotificationType[])?.slice(0, 6).map((items) => {
+                ? (data as NotificationType[])?.map((items) => {
                       return <Notification key={items.id} items={items} />;
                   })
                 : 'No notifications'}

--- a/deployment/frontend/src/pages/dashboard/activity-stream.tsx
+++ b/deployment/frontend/src/pages/dashboard/activity-stream.tsx
@@ -21,21 +21,22 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
         ctx: { session, ip: undefined },
         transformer: superjson,
     });
-    await helpers.notification.getAllNotifications.prefetch({});
-    await helpers.user.getUserCapacity.prefetch();
-    await helpers.dashboardActivity.listActivityStreamDashboard.prefetch({
-        search: '',
-        fq: {},
-        page: { start: 0, rows: 1000 },
-    });
-    await helpers.dataset.getPendingDatasets.prefetch({
-        search: '',
-        page: { start: 0, rows: 10 },
-        sortBy: 'metadata_modified desc',
-    });
-    await helpers.dataset.getFavoriteDataset.prefetch();
-    await helpers.organization.getAllOrganizations.prefetch();
-    await helpers.topics.getAllTopics.prefetch();
+    await Promise.all([
+        helpers.notification.getAllNotifications.prefetch({}),
+        helpers.user.getUserCapacity.prefetch(),
+        helpers.dashboardActivity.listActivityStreamDashboard.prefetch({
+            search: '',
+            fq: {},
+            page: { start: 0, rows: 1000 },
+        }),
+        helpers.dataset.getPendingDatasets.prefetch({
+            search: '',
+            page: { start: 0, rows: 0 },
+            sortBy: 'metadata_modified desc',
+        }),
+        helpers.organization.getAllOrganizations.prefetch(),
+        helpers.topics.getAllTopics.prefetch(),
+    ]);
 
     return {
         props: {

--- a/deployment/frontend/src/pages/dashboard/approval-request.tsx
+++ b/deployment/frontend/src/pages/dashboard/approval-request.tsx
@@ -22,12 +22,20 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
         transformer: superjson,
     });
 
-    await helpers.notification.getAllNotifications.prefetch({});
-    await helpers.dataset.getPendingDatasets.prefetch({
-        search: '',
-        page: { start: 0, rows: 10 },
-        sortBy: 'metadata_modified desc',
-    });
+    await Promise.all([
+        helpers.notification.getAllNotifications.prefetch({}),
+        helpers.user.getUserCapacity.prefetch(),
+        helpers.dataset.getPendingDatasets.prefetch({
+            search: '',
+            page: { start: 0, rows: 10 },
+            sortBy: 'metadata_modified desc',
+        }),
+        helpers.dataset.getPendingDatasets.prefetch({
+            search: '',
+            page: { start: 0, rows: 0 },
+            sortBy: 'metadata_modified desc',
+        }),
+    ]);
 
     return {
         props: {

--- a/deployment/frontend/src/pages/dashboard/index.tsx
+++ b/deployment/frontend/src/pages/dashboard/index.tsx
@@ -53,6 +53,17 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
             search: '',
             page: { start: 0, rows: 6 },
         }),
+        helpers.dataset.getFavoriteDataset.prefetch({ preview: true }),
+        helpers.notification.getAllNotifications.prefetch({}),
+        helpers.notification.getAllNotifications.prefetch({
+            returnLength: true,
+            limit: 6,
+        }),
+        helpers.dataset.getPendingDatasets.prefetch({
+            search: '',
+            page: { start: 0, rows: 0 },
+            sortBy: 'metadata_modified desc',
+        }),
     ]);
 
     if (!session) {

--- a/deployment/frontend/src/pages/dashboard/notifications.tsx
+++ b/deployment/frontend/src/pages/dashboard/notifications.tsx
@@ -21,16 +21,18 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
         ctx: { session, ip: undefined },
         transformer: superjson,
     });
-    await helpers.notification.getAllNotifications.prefetch({
-        returnLength: true,
-    });
-    await helpers.user.getUserCapacity.prefetch();
-
-    await helpers.dataset.getPendingDatasets.prefetch({
-        search: '',
-        page: { start: 0, rows: 10 },
-        sortBy: 'metadata_modified desc',
-    });
+    await Promise.all([
+        helpers.notification.getAllNotifications.prefetch({
+            returnLength: true,
+        }),
+        helpers.notification.getAllNotifications.prefetch({}),
+        helpers.user.getUserCapacity.prefetch(),
+        helpers.dataset.getPendingDatasets.prefetch({
+            search: '',
+            page: { start: 0, rows: 0 },
+            sortBy: 'metadata_modified desc',
+        }),
+    ]);
     return {
         props: {
             trpcState: helpers.dehydrate(),

--- a/deployment/frontend/src/pages/dashboard/teams/index.tsx
+++ b/deployment/frontend/src/pages/dashboard/teams/index.tsx
@@ -23,12 +23,14 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
         transformer: superjson,
     });
 
-    await helpers.notification.getAllNotifications.prefetch({});
-    await helpers.user.getUserCapacity.prefetch();
-    await helpers.organization.getUsersOrganizations.prefetch({
-        search: '',
-        page: { start: 0, rows: 10 },
-    });
+    await Promise.all([
+        helpers.notification.getAllNotifications.prefetch({}),
+        helpers.user.getUserCapacity.prefetch(),
+        helpers.organization.getUsersOrganizations.prefetch({
+            search: '',
+            page: { start: 0, rows: 10 },
+        }),
+    ]);
     if (!session) {
         return {
             redirect: {

--- a/deployment/frontend/src/pages/dashboard/topics/index.tsx
+++ b/deployment/frontend/src/pages/dashboard/topics/index.tsx
@@ -22,12 +22,14 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
         transformer: superjson,
     });
 
-    await helpers.notification.getAllNotifications.prefetch({});
-    await helpers.user.getUserCapacity.prefetch();
-    await helpers.topics.getUsersTopics.prefetch({
-        search: '',
-        page: { start: 0, rows: 10 },
-    });
+    await Promise.all([
+        helpers.notification.getAllNotifications.prefetch({}),
+        helpers.user.getUserCapacity.prefetch(),
+        helpers.topics.getUsersTopics.prefetch({
+            search: '',
+            page: { start: 0, rows: 10 },
+        }),
+    ]);
     if (!session) {
         return {
             redirect: {

--- a/deployment/frontend/src/server/api/routers/User.ts
+++ b/deployment/frontend/src/server/api/routers/User.ts
@@ -27,26 +27,21 @@ import { type ApiToken } from '@/interfaces/user.interface';
 
 export const UserRouter = createTRPCRouter({
   getDashboardUser: protectedProcedure.query(async ({ ctx }) => {
-    const userdetails = await getUser({
-      userId: ctx.session.user.id,
-      apiKey: ctx.session.user.apikey,
-    });
-    const organizations = await getUserOrganizations({
-      userId: ctx.session.user.id,
-      apiKey: ctx.session.user.apikey,
-    });
-    const TeamCount = organizations?.length;
-    const dataset = await getUserDataset({
-      userId: ctx.session.user.id,
-      apiKey: ctx.session.user.apikey,
-    });
-    const DatasetCount = dataset?.count;
+    const userId = ctx.session.user.id;
+    const apiKey = ctx.session.user.apikey;
+
+    const [userdetails, organizations, dataset] = await Promise.all([
+      getUser({ userId, apiKey }),
+      getUserOrganizations({ userId, apiKey }),
+      getUserDataset({ userId, apiKey, countOnly: true }),
+    ]);
+
     const dashboardUser = {
       imageUrl: userdetails?.image_display_url,
       name: userdetails?.name,
       email: userdetails?.email,
-      teamCount: TeamCount,
-      datasetCount: DatasetCount,
+      teamCount: organizations?.length,
+      datasetCount: dataset?.count,
       isSysAdmin: userdetails?.sysadmin,
       email_hash: userdetails?.email_hash,
     };

--- a/deployment/frontend/src/server/api/routers/activityStream.ts
+++ b/deployment/frontend/src/server/api/routers/activityStream.ts
@@ -12,6 +12,14 @@ import type {
 import { activityDetails } from '@/utils/apiUtils';
 import { searchSchema } from '@/schema/search.schema';
 
+function withPaginationParams(
+    url: string,
+    page: { start: number; rows: number }
+) {
+    const separator = url.includes('?') ? '&' : '?';
+    return `${url}${separator}limit=${page.rows}&offset=${page.start}`;
+}
+
 export const activityStreamRouter = createTRPCRouter({
     listPackageActivity: publicProcedure
         .input(z.object({ id: z.string() }))
@@ -57,6 +65,9 @@ export const activityStreamRouter = createTRPCRouter({
                     }
                 }
             }
+
+            url = withPaginationParams(url, input.page);
+
             const response = await fetch(url, {
                 headers: {
                     Authorization: ctx.session.user.apikey,
@@ -110,13 +121,8 @@ export const activityStreamRouter = createTRPCRouter({
             }
 
             return {
-                activity: result
-                    ? result.slice(
-                          input.page.start,
-                          input.page.start + input.page.rows
-                      )
-                    : [],
-                count: result.length,
+                activity: result ?? [],
+                count: result?.length ?? 0,
             };
         }),
 });

--- a/deployment/frontend/src/server/api/routers/dataset.ts
+++ b/deployment/frontend/src/server/api/routers/dataset.ts
@@ -130,6 +130,25 @@ async function fetchDatasetCollaborators(
   return collaborators.result;
 }
 
+async function fetchFolloweeDatasets(user: {
+  id: string;
+  apikey: string;
+}): Promise<WriDataset[]> {
+  const response = await fetch(
+    `${env.CKAN_URL}/api/3/action/dataset_followee_list?id=${user.id}`,
+    {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `${user.apikey}`,
+      },
+    }
+  );
+  const data = (await response.json()) as CkanResponse<WriDataset[]>;
+  if (!data.success && data.error) throw Error(data.error.message);
+
+  return data.result ?? [];
+}
+
 export const DatasetRouter = createTRPCRouter({
   createDataset: protectedProcedure
     .input(DatasetSchema)
@@ -1162,24 +1181,37 @@ export const DatasetRouter = createTRPCRouter({
         count: dataset.count,
       };
     }),
-  getFavoriteDataset: protectedProcedure.query(async ({ ctx }) => {
-    const response = await fetch(
-      `${env.CKAN_URL}/api/3/action/dataset_followee_list?id=${ctx.session.user.id}`,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `${ctx.session.user.apikey}`,
-        },
-      }
-    );
-    const data = (await response.json()) as CkanResponse<WriDataset[]>;
-    if (!data.success && data.error) throw Error(data.error.message);
+  getFavoriteDataset: protectedProcedure
+    .input(
+      z
+        .object({
+          preview: z.boolean().optional(),
+        })
+        .optional()
+    )
+    .query(async ({ ctx, input }): Promise<{ datasets: WriDataset[]; count: number }> => {
+      const datasets = await fetchFolloweeDatasets(ctx.session.user);
 
-    return {
-      datasets: data.result,
-      count: data.result?.length,
-    };
-  }),
+      if (input?.preview) {
+        return {
+          datasets: datasets.slice(0, 10).map((dataset) => ({
+            id: dataset.id,
+            name: dataset.name,
+            title: dataset.title,
+            metadata_modified: dataset.metadata_modified,
+            creator_user_id: dataset.creator_user_id,
+            approval_status: dataset.approval_status,
+            owner_org: dataset.owner_org,
+          })) as WriDataset[],
+          count: datasets.length,
+        };
+      }
+
+      return {
+        datasets,
+        count: datasets.length,
+      };
+    }),
   getFeaturedDatasets: publicProcedure
     .input(
       searchSchema.extend({

--- a/deployment/frontend/src/server/api/routers/notification.ts
+++ b/deployment/frontend/src/server/api/routers/notification.ts
@@ -67,7 +67,12 @@ function parseNotificationList(
 
 export const notificationRouter = createTRPCRouter({
     getAllNotifications: protectedProcedure
-        .input(z.object({ returnLength: z.boolean().optional() }))
+        .input(
+            z.object({
+                returnLength: z.boolean().optional(),
+                limit: z.number().int().positive().optional(),
+            })
+        )
         .query(async ({ input, ctx }) => {
             const authHeader = env.SYS_ADMIN_API_KEY;
             const recipientId = ctx.session.user.id;
@@ -89,8 +94,11 @@ export const notificationRouter = createTRPCRouter({
                 return { count: parseNotificationCount(data) };
             }
 
+            const limitParam =
+                input.limit !== undefined ? `&limit=${input.limit}` : '';
+
             const response = await fetch(
-                `${env.CKAN_URL}/api/3/action/notification_get_all?recipient_id=${recipientId}`,
+                `${env.CKAN_URL}/api/3/action/notification_get_all?recipient_id=${recipientId}${limitParam}`,
                 {
                     headers: {
                         Authorization: authHeader,
@@ -115,16 +123,18 @@ export const notificationRouter = createTRPCRouter({
 
             for (const notification of notifications) {
                 if (notification.state === 'deleted') continue;
+                if (!notification.sender_obj) continue;
 
-                const user_data = notification.sender_obj!;
+                const user_data = notification.sender_obj;
 
                 let objectName = '';
                 let objectIdName = '';
                 let msg = '';
                 if (notification.object_type === 'dataset') {
-                    const dataset = notification.object_data as WriDataset;
-                    objectName = dataset?.title ?? dataset?.name ?? '';
-                    objectIdName = dataset?.name;
+                    const dataset = notification.object_data as WriDataset | undefined;
+                    if (!dataset) continue;
+                    objectName = dataset.title ?? dataset.name ?? '';
+                    objectIdName = dataset.name;
 
                     const actionType = notification.activity_type.split('_');
 
@@ -189,7 +199,9 @@ export const notificationRouter = createTRPCRouter({
                         teamOrTopic = notification.object_data as Topic;
                     }
 
-                    objectName = teamOrTopic?.title ?? teamOrTopic?.name ?? '';
+                    if (!teamOrTopic) continue;
+
+                    objectName = teamOrTopic.title ?? teamOrTopic.name ?? '';
                     objectIdName = teamOrTopic?.name ?? '';
 
                     const actionType = notification.activity_type.split('_');
@@ -227,7 +239,7 @@ export const notificationRouter = createTRPCRouter({
         }),
     updateNotification: protectedProcedure
         .input(NotificationInput)
-        .mutation(async ({ input, ctx }) => {
+        .mutation(async ({ input }) => {
             try {
                 const notificationPayload: NotificationType[] =
                     input.notifications.map((notification) => {

--- a/deployment/frontend/src/server/api/routers/notification.ts
+++ b/deployment/frontend/src/server/api/routers/notification.ts
@@ -10,15 +10,90 @@ import type Team from '@/interfaces/team.interface';
 import type Topic from '@/interfaces/topic.interface';
 import { z } from 'zod';
 
+function parseNotificationCount(
+    data: CkanResponse<NotificationType[] | { count: number }>
+): number {
+    if (!data.success) {
+        if (data.error?.message) {
+            throw Error(replaceNames(data.error.message, true));
+        }
+        throw Error(
+            replaceNames(
+                data.error
+                    ? JSON.stringify(data.error)
+                    : 'Failed to fetch notifications',
+                true
+            )
+        );
+    }
+
+    if (
+        data.result &&
+        typeof data.result === 'object' &&
+        !Array.isArray(data.result) &&
+        'count' in data.result
+    ) {
+        return data.result.count;
+    }
+
+    if (!Array.isArray(data.result)) {
+        return 0;
+    }
+
+    return data.result.filter(
+        (notification) => notification.is_unread && notification.state !== 'deleted'
+    ).length;
+}
+
+function parseNotificationList(
+    data: CkanResponse<NotificationType[]>
+): NotificationType[] {
+    if (!data.success) {
+        if (data.error?.message) {
+            throw Error(replaceNames(data.error.message, true));
+        }
+        throw Error(
+            replaceNames(
+                data.error
+                    ? JSON.stringify(data.error)
+                    : 'Failed to fetch notifications',
+                true
+            )
+        );
+    }
+
+    return Array.isArray(data.result) ? data.result : [];
+}
+
 export const notificationRouter = createTRPCRouter({
     getAllNotifications: protectedProcedure
         .input(z.object({ returnLength: z.boolean().optional() }))
         .query(async ({ input, ctx }) => {
+            const authHeader = env.SYS_ADMIN_API_KEY;
+            const recipientId = ctx.session.user.id;
+
+            if (!input.returnLength) {
+                const response = await fetch(
+                    `${env.CKAN_URL}/api/3/action/notification_get_all?recipient_id=${recipientId}&count_only=true`,
+                    {
+                        headers: {
+                            Authorization: authHeader,
+                        },
+                    }
+                );
+
+                const data = (await response.json()) as CkanResponse<
+                    NotificationType[] | { count: number }
+                >;
+
+                return { count: parseNotificationCount(data) };
+            }
+
             const response = await fetch(
-                `${env.CKAN_URL}/api/3/action/notification_get_all?recipient_id=${ctx.session.user.id}`,
+                `${env.CKAN_URL}/api/3/action/notification_get_all?recipient_id=${recipientId}`,
                 {
                     headers: {
-                        Authorization: env.SYS_ADMIN_API_KEY,
+                        Authorization: authHeader,
                     },
                 }
             );
@@ -27,13 +102,7 @@ export const notificationRouter = createTRPCRouter({
                 NotificationType[]
             >;
 
-            if (!input.returnLength) {
-                return {
-                    count: data.result.filter(
-                        (x) => x.is_unread && x.state !== 'deleted'
-                    ).length,
-                };
-            }
+            const notifications = parseNotificationList(data);
 
             const activities: NotificationType[] = [];
 
@@ -44,7 +113,7 @@ export const notificationRouter = createTRPCRouter({
                     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
                     .join(' ');
 
-            for (const notification of data.result) {
+            for (const notification of notifications) {
                 if (notification.state === 'deleted') continue;
 
                 const user_data = notification.sender_obj!;

--- a/deployment/frontend/src/utils/apiUtils.ts
+++ b/deployment/frontend/src/utils/apiUtils.ts
@@ -455,13 +455,15 @@ export async function getCollaboratorPackages({
 export async function getUserDataset({
     userId,
     apiKey,
+    countOnly = false,
 }: {
     userId: string;
     apiKey: string;
+    countOnly?: boolean;
 }): Promise<{ datasets: WriDataset[]; count: number } | null> {
     try {
         const response = await fetch(
-            `${env.CKAN_URL}/api/3/action/package_search?q=creator_user_id:${userId}`,
+            `${env.CKAN_URL}/api/3/action/package_search?q=creator_user_id:${userId}&rows=${countOnly ? 0 : 1000}`,
             {
                 headers: {
                     Authorization: apiKey,
@@ -472,7 +474,7 @@ export async function getUserDataset({
             results: WriDataset[];
             count: number;
         }>;
-        const datasets = data.result.results;
+        const datasets = countOnly ? [] : data.result.results;
         const count = data.result.count;
         return { datasets, count };
     } catch (e) {

--- a/deployment/frontend/src/utils/apiUtils.ts
+++ b/deployment/frontend/src/utils/apiUtils.ts
@@ -463,7 +463,7 @@ export async function getUserDataset({
 }): Promise<{ datasets: WriDataset[]; count: number } | null> {
     try {
         const response = await fetch(
-            `${env.CKAN_URL}/api/3/action/package_search?q=creator_user_id:${userId}&rows=${countOnly ? 0 : 1000}`,
+            `${env.CKAN_URL}/api/3/action/package_search?q=creator_user_id:${userId}${countOnly ? '&rows=0' : ''}`,
             {
                 headers: {
                     Authorization: apiKey,


### PR DESCRIPTION
# Improve performance for user experience

<img width="692" height="155" alt="Screenshot 2026-07-03 at 1 46 13 PM" src="https://github.com/user-attachments/assets/2c9779b4-f88b-40f7-9893-83a3afbc5bf3" />

loading times of the dashboard are over 5 seconds for the api requests

## Summary

Dashboard load times were exceeding 5 seconds due to batched tRPC requests fetching and processing far more data than the UI actually renders. This PR reduces payload sizes, avoids redundant CKAN work, and improves SSR prefetching across dashboard pages.

### Problem

On dashboard load, a single batched request could include:

- All notifications (full enrichment, multi-MB payloads)
- All activity stream entries (processed client-side, then sliced to 6)
- Full dataset objects for favourites (resources, extras, etc.)
- 100 pending datasets when only a badge count was needed
- Sequential CKAN round trips during SSR

### Frontend changes

**Notifications**
- Sidebar badge uses a lightweight `count_only` query instead of fetching the full list
- Dashboard widget fetches only the latest 6 notifications via a new `limit` param
- Unread badge on the widget reuses the shared count query (deduped with Layout)
- Skips notifications with missing sender or object data

**Activity stream**
- Passes `limit`/`offset` to CKAN instead of fetching all activities and slicing in Node
- Dashboard widget requests 6 rows; full activity page requests up to 1000 (CKAN caps at `activity_list_limit_max`)

**Favourites**
- `getFavoriteDataset` accepts optional `{ preview: true }` for the dashboard widget
- Preview mode returns 10 items with only the 7 fields the cards render
- Full favourites page continues to use the complete dataset list unchanged

**Pending approvals badge**
- Layout sidebar badge uses `rows: 0` (count only) instead of fetching 100 full datasets

**User profile (`getDashboardUser`)**
- Parallelizes CKAN calls with `Promise.all`
- Dataset count uses `rows=0` on `package_search` instead of fetching up to 1000 results

**Header**
- Removes forced API token refetch on auth; uses `staleTime: 5min` instead

**SSR prefetching**
- Dashboard home, activity stream, notifications, approval request, teams, and topics pages now prefetch in parallel via `Promise.all`
- Prefetch query keys aligned with client queries (e.g. pending badge uses `rows: 0`, not `rows: 10`)
- Dashboard home prefetches favourites preview, notification count, and notification preview

### CKAN backend changes (`ckanext-wri`)

**`notification_get_all`**
- New `count_only` param returns `{ count: N }` for unread notifications without enrichment
- New `limit` param stops enrichment after N valid notifications
- Skips deleted notifications during enrichment (never rendered by frontend)
- Limit applied after filtering orphans/deleted, so preview widgets always get the requested number of items

**`Notification.get` model query**
- Orders by `time_sent DESC` so limited/preview queries return the most recent notifications

### Expected impact

| Endpoint | Before | After |
|---|---|---|
| Notification badge | Full list enriched | Count-only query |
| Notification widget | All notifications | Latest 6 enriched |
| Activity stream widget | All activities processed | 6 from CKAN |
| Favourites widget | Full dataset blobs | 10 items, 7 fields |
| Pending badge | 100 datasets fetched | Count only |
| Dashboard SSR | Sequential prefetches | Parallel prefetches |

## Test plan

- [ ] Load `/dashboard` — batched tRPC request completes in under ~2s (was 5s+)
- [ ] Notification sidebar badge shows correct unread count
- [ ] Notifications widget shows latest 6 items with correct unread badge
- [ ] Activity stream widget shows 6 recent activities
- [ ] Favourites widget shows up to 10 items with approval tags
- [ ] Pending approval sidebar badge shows correct count (org admin / sysadmin only)
- [ ] `/dashboard/notifications` — full paginated list still works
- [ ] `/dashboard/activity-stream` — filtering, search, and pagination still work
- [ ] `/dashboard/datasets?tab=favourites` — full favourites list with search/pagination still works
- [ ] User profile card shows correct team and dataset counts
- [ ] Deploy CKAN extension changes to dev before testing notification/activity limits end-to-end

## Deployment notes

Both **frontend** and **CKAN backend** (`ckanext-wri`) must be deployed for full benefit. Notification `count_only`, `limit`, and ordering changes are CKAN-side.