### PR TITLE
ODP-645 - Build Dataset Detail sticky header component

### DIFF
--- a/deployment/frontend/src/components/datasets-v2/DatasetDetailsHeader/DatasetDetailsHeaderContent.tsx
+++ b/deployment/frontend/src/components/datasets-v2/DatasetDetailsHeader/DatasetDetailsHeaderContent.tsx
@@ -1,0 +1,97 @@
+import {
+    Button,
+    getThemedColor,
+    getThemedFontSize,
+    getThemedSpacing,
+    Menu,
+} from '@worldresources/wri-design-systems';
+import { ArrowDownTrayIcon, GlobeAltIcon } from '@heroicons/react/24/outline';
+import { ChevronDownIcon, ArrowTopRightOnSquareIcon } from '@heroicons/react/20/solid';
+import type { DatasetDetailsHeaderContentProps } from './types';
+
+export default function DatasetDetailsHeaderContent({
+    datasetTitle,
+    datasetDescription,
+    openInItems,
+}: DatasetDetailsHeaderContentProps) {
+    const hasSingleOpenInOption = openInItems.length === 1;
+    const singleOpenInItem = hasSingleOpenInOption ? openInItems[0] : undefined;
+    const openInTriggerLabel = hasSingleOpenInOption
+        ? `Open in (${singleOpenInItem?.label ?? 'app'})`
+        : 'Open in app';
+
+    const onOpenInSelect = (value: string) => {
+        window.open(value, '_blank', 'noopener,noreferrer');
+    };
+
+    return (
+        <div
+            className="font-acumin"
+            style={{
+                backgroundColor: getThemedColor('secondary', 100),
+                padding: `${getThemedSpacing(800)} ${getThemedSpacing(600)} ${getThemedSpacing(900)} ${getThemedSpacing(600)}`,
+                borderBottom: `1px solid ${getThemedColor('neutral', 300)}`,
+            }}
+        >
+            <h1
+                style={{
+                    fontSize: getThemedFontSize(900),
+                    color: getThemedColor('secondary', 900),
+                    fontWeight: 700,
+                }}
+            >
+                {datasetTitle}
+            </h1>
+
+            <p className="mt-4 text-lg text-stone-600">{datasetDescription ?? 'No description.'}</p>
+
+            <div
+                style={{
+                    display: 'flex',
+                    gap: getThemedSpacing(400),
+                    marginTop: getThemedSpacing(400),
+                }}
+            >
+                <Button variant="primary" size="default" leftIcon={<ArrowDownTrayIcon />}>
+                    Download
+                </Button>
+
+                <Button variant="secondary" size="default" leftIcon={<GlobeAltIcon />}>
+                    Access API
+                </Button>
+
+                {hasSingleOpenInOption && singleOpenInItem?.value ? (
+                    <Button
+                        variant="secondary"
+                        size="default"
+                        leftIcon={<ArrowTopRightOnSquareIcon />}
+                        onClick={() => {
+                            if (singleOpenInItem?.value) {
+                                onOpenInSelect(singleOpenInItem.value);
+                            }
+                        }}
+                    >
+                        {openInTriggerLabel}
+                    </Button>
+                ) : openInItems.length > 0 ? (
+                    <Menu
+                        label="Open in"
+                        items={openInItems}
+                        onSelect={onOpenInSelect}
+                        hideArrow
+                        customTrigger={
+                            <Button
+                                variant="secondary"
+                                size="default"
+                                leftIcon={<ArrowTopRightOnSquareIcon />}
+                                rightIcon={<ChevronDownIcon />}
+                            >
+                                {openInTriggerLabel}
+                            </Button>
+                        }
+                    />
+                ) : null}
+            </div>
+        </div>
+    );
+}

--- a/deployment/frontend/src/components/datasets-v2/DatasetDetailsHeader/DatasetDetailsHeaderContent.tsx
+++ b/deployment/frontend/src/components/datasets-v2/DatasetDetailsHeader/DatasetDetailsHeaderContent.tsx
@@ -46,8 +46,8 @@ export default function DatasetDetailsHeaderContent({
             <p className="mt-4 text-lg text-stone-600">{datasetDescription ?? 'No description.'}</p>
 
             <div
+                className="flex flex-col md:flex-row md:items-center"
                 style={{
-                    display: 'flex',
                     gap: getThemedSpacing(400),
                     marginTop: getThemedSpacing(400),
                 }}

--- a/deployment/frontend/src/components/datasets-v2/DatasetDetailsHeader/DatasetDetailsHeaderSticky.tsx
+++ b/deployment/frontend/src/components/datasets-v2/DatasetDetailsHeader/DatasetDetailsHeaderSticky.tsx
@@ -1,0 +1,165 @@
+import { useRef } from 'react';
+import {
+    Button,
+    getThemedColor,
+    getThemedFontSize,
+    getThemedSpacing,
+    Menu,
+} from '@worldresources/wri-design-systems';
+import { ArrowDownTrayIcon, ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline';
+import { ChevronDownIcon, EllipsisVerticalIcon } from '@heroicons/react/20/solid';
+import type { DatasetDetailsHeaderStickyProps } from './types';
+
+const sectionItems = [
+    {
+        label: 'Key details',
+        value: 'key-details',
+    },
+    {
+        label: 'Description',
+        value: 'description',
+    },
+    {
+        label: 'Additional Reading',
+        value: 'additional-reading',
+    },
+    {
+        label: 'Citation',
+        value: 'citation',
+    },
+    {
+        label: 'Methodology',
+        value: 'methodology',
+    },
+    {
+        label: 'Contact details',
+        value: 'contact-details',
+    },
+    {
+        label: 'Related datasets',
+        value: 'related-datasets',
+    },
+
+    {
+        label: 'Release notes',
+        value: 'release-notes',
+    },
+    {
+        label: 'Additional metadata',
+        value: 'additional-metadata',
+    },
+];
+
+function DatasetDetailsHeaderSticky({
+    datasetTitle,
+    openInItems,
+}: DatasetDetailsHeaderStickyProps) {
+    const stickyHeaderRef = useRef<HTMLDivElement>(null);
+    const stickyOpenInItems = openInItems.map((item) => ({
+        label: `Open in (${item.label})`,
+        value: item.value,
+        endIcon: <ArrowTopRightOnSquareIcon />,
+    }));
+
+    const onOpenInSelect = (value: string) => {
+        if (value === 'access-api') {
+            console.log('Access API clicked');
+            return;
+        }
+
+        window.open(value, '_blank', 'noopener,noreferrer');
+    };
+    const openInItemsAndAccessApi = [
+        {
+            label: 'Access API',
+            value: 'access-api',
+        },
+        ...stickyOpenInItems,
+    ];
+
+    const onSectionSelect = (sectionId: string) => {
+        const targetElement = document.getElementById(sectionId);
+
+        if (!targetElement) {
+            return;
+        }
+
+        const navbarHeight = Number.parseFloat(
+            getComputedStyle(document.documentElement).getPropertyValue(
+                '--dataset-v2-navbar-height'
+            )
+        );
+        const stickyHeaderHeight = stickyHeaderRef.current?.getBoundingClientRect().height ?? 0;
+        const offset = navbarHeight + stickyHeaderHeight;
+
+        window.scrollTo({
+            top: targetElement.getBoundingClientRect().top + window.scrollY - offset,
+            behavior: 'smooth',
+        });
+    };
+
+    return (
+        <div
+            ref={stickyHeaderRef}
+            className="sticky z-600 top-12 left-0 right-0 z-50 font-acumin"
+            style={{
+                backgroundColor: getThemedColor('neutral', 100),
+                padding: `${getThemedSpacing(300)} ${getThemedSpacing(600)}`,
+                borderBottom: `1px solid ${getThemedColor('neutral', 300)}`,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+            }}
+        >
+            <h1
+                style={{
+                    fontSize: getThemedFontSize(500),
+                    color: getThemedColor('neutral', 800),
+                    fontWeight: 700,
+                }}
+            >
+                {datasetTitle}
+            </h1>
+
+            <div
+                style={{
+                    display: 'flex',
+                    gap: getThemedSpacing(400),
+                }}
+            >
+                <Button variant="primary" size="small" leftIcon={<ArrowDownTrayIcon />}>
+                    Download
+                </Button>
+
+                <Menu
+                    label="Section"
+                    items={sectionItems}
+                    onSelect={onSectionSelect}
+                    hideArrow
+                    customTrigger={
+                        <Button variant="secondary" size="small" rightIcon={<ChevronDownIcon />}>
+                            <span style={{ fontSize: getThemedFontSize(200), fontWeight: 400 }}>
+                                Section:
+                            </span>
+                            <span style={{ fontSize: getThemedFontSize(200), fontWeight: 700 }}>
+                                Key details
+                            </span>
+                        </Button>
+                    }
+                />
+
+                {openInItemsAndAccessApi.length > 0 && (
+                    <Menu
+                        label="Open in"
+                        items={openInItemsAndAccessApi}
+                        onSelect={onOpenInSelect}
+                        hideArrow
+                        customTrigger={<EllipsisVerticalIcon height={24} />}
+                    />
+                )}
+            </div>
+        </div>
+    );
+}
+
+export default DatasetDetailsHeaderSticky;

--- a/deployment/frontend/src/components/datasets-v2/DatasetDetailsHeader/DatasetDetailsHeaderSticky.tsx
+++ b/deployment/frontend/src/components/datasets-v2/DatasetDetailsHeader/DatasetDetailsHeaderSticky.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import {
     Button,
     getThemedColor,
@@ -55,6 +55,7 @@ function DatasetDetailsHeaderSticky({
     openInItems,
 }: DatasetDetailsHeaderStickyProps) {
     const stickyHeaderRef = useRef<HTMLDivElement>(null);
+    const [selectedSectionLabel, setSelectedSectionLabel] = useState('Key details');
     const stickyOpenInItems = openInItems.map((item) => ({
         label: `Open in (${item.label})`,
         value: item.value,
@@ -78,6 +79,12 @@ function DatasetDetailsHeaderSticky({
     ];
 
     const onSectionSelect = (sectionId: string) => {
+        const selectedSection = sectionItems.find((item) => item.value === sectionId);
+
+        if (selectedSection?.label) {
+            setSelectedSectionLabel(selectedSection.label);
+        }
+
         const targetElement = document.getElementById(sectionId);
 
         if (!targetElement) {
@@ -122,12 +129,7 @@ function DatasetDetailsHeaderSticky({
                 {datasetTitle}
             </h1>
 
-            <div
-                style={{
-                    display: 'flex',
-                    gap: getThemedSpacing(400),
-                }}
-            >
+            <div className="flex gap-1 sm:gap-4">
                 <Button variant="primary" size="small" leftIcon={<ArrowDownTrayIcon />}>
                     Download
                 </Button>
@@ -142,8 +144,11 @@ function DatasetDetailsHeaderSticky({
                             <span style={{ fontSize: getThemedFontSize(200), fontWeight: 400 }}>
                                 Section:
                             </span>
-                            <span style={{ fontSize: getThemedFontSize(200), fontWeight: 700 }}>
-                                Key details
+                            <span
+                                className="hidden sm:inline"
+                                style={{ fontSize: getThemedFontSize(200), fontWeight: 700 }}
+                            >
+                                {selectedSectionLabel}
                             </span>
                         </Button>
                     }

--- a/deployment/frontend/src/components/datasets-v2/DatasetDetailsHeader/DatasetDetailsHeaderSticky.tsx
+++ b/deployment/frontend/src/components/datasets-v2/DatasetDetailsHeader/DatasetDetailsHeaderSticky.tsx
@@ -84,11 +84,12 @@ function DatasetDetailsHeaderSticky({
             return;
         }
 
-        const navbarHeight = Number.parseFloat(
-            getComputedStyle(document.documentElement).getPropertyValue(
-                '--dataset-v2-navbar-height'
-            )
+        const navbarHeightRaw = getComputedStyle(document.documentElement).getPropertyValue(
+            '--dataset-v2-navbar-height'
         );
+        const navbarHeightParsed = Number.parseFloat(navbarHeightRaw);
+        const navbarHeight = Number.isFinite(navbarHeightParsed) ? navbarHeightParsed : 0;
+
         const stickyHeaderHeight = stickyHeaderRef.current?.getBoundingClientRect().height ?? 0;
         const offset = navbarHeight + stickyHeaderHeight;
 
@@ -101,7 +102,7 @@ function DatasetDetailsHeaderSticky({
     return (
         <div
             ref={stickyHeaderRef}
-            className="sticky z-600 top-12 left-0 right-0 z-50 font-acumin"
+            className="sticky z-50 top-12 left-0 right-0 font-acumin"
             style={{
                 backgroundColor: getThemedColor('neutral', 100),
                 padding: `${getThemedSpacing(300)} ${getThemedSpacing(600)}`,

--- a/deployment/frontend/src/components/datasets-v2/DatasetDetailsHeader/index.tsx
+++ b/deployment/frontend/src/components/datasets-v2/DatasetDetailsHeader/index.tsx
@@ -1,0 +1,131 @@
+import {
+    Button,
+    getThemedColor,
+    getThemedFontSize,
+    getThemedSpacing,
+} from '@worldresources/wri-design-systems';
+import { ChevronLeftIcon, CopyIcon } from '@radix-ui/react-icons';
+import { useRouter } from 'next/router';
+import type {
+    DatasetDetailsHeaderDataset,
+    DatasetDetailsHeaderMenuItem,
+    DatasetDetailsHeaderProps,
+} from './types';
+import useStickyHeader from './useStickyHeader';
+import DatasetDetailsHeaderContent from './DatasetDetailsHeaderContent';
+import DatasetDetailsHeaderSticky from './DatasetDetailsHeaderSticky';
+
+function normalizeOpenInItems(
+    dataset?: DatasetDetailsHeaderDataset
+): DatasetDetailsHeaderMenuItem[] {
+    const baseOpenIn = (dataset?.open_in ?? []).map((item: { title: string; url: string }) => ({
+        label: item.title,
+        value: item.url,
+    }));
+
+    const providerOpenIn: DatasetDetailsHeaderMenuItem[] =
+        dataset?.provider === 'cartodb' && dataset.connectorUrl
+            ? [{ label: 'Carto', value: dataset.connectorUrl }]
+            : dataset?.provider === 'featureservice' && dataset.connectorUrl
+              ? [{ label: 'ArcGIS', value: dataset.connectorUrl }]
+              : dataset?.provider === 'gfw' && dataset.connectorUrl
+                ? [{ label: 'GFW', value: dataset.connectorUrl }]
+                : dataset?.provider === 'gee' && dataset.tableName
+                  ? [
+                        {
+                            label: 'GEE',
+                            value: `https://developers.google.com/earth-engine/datasets/catalog/${dataset.tableName.replaceAll('/', '_')}`,
+                        },
+                    ]
+                  : (dataset?.sources ?? []).map((source, index) => ({
+                        label:
+                            (dataset?.sources?.length ?? 0) === 1
+                                ? (dataset?.provider?.toUpperCase() ?? 'SOURCE')
+                                : `Source ${index + 1}`,
+                        value: source,
+                    }));
+
+    return [...baseOpenIn, ...providerOpenIn];
+}
+
+function DatasetDetailsHeader({
+    datasetTitle,
+    datasetDescription,
+    datasetName,
+    dataset,
+}: DatasetDetailsHeaderProps) {
+    const router = useRouter();
+    const { headerRef, isSticky } = useStickyHeader();
+
+    const copyLink = `${process.env.NEXT_PUBLIC_NEXTAUTH_URL?.replace(/\/+$/, '') ?? ''}/datasets-v2/${dataset?.name ?? datasetName}`;
+    const openInItems = normalizeOpenInItems(dataset);
+
+    return (
+        <>
+            <div
+                style={{
+                    backgroundColor: getThemedColor('secondary', 100),
+                    paddingTop: getThemedSpacing(800),
+                }}
+                className="flex justify-between items-center px-2 w-100"
+            >
+                <Button
+                    variant="borderless"
+                    size="default"
+                    onClick={() => router.back()}
+                    leftIcon={<ChevronLeftIcon />}
+                >
+                    <div
+                        style={{
+                            color: getThemedColor('neutral', 700),
+                            fontWeight: 400,
+                            fontSize: getThemedFontSize(300),
+                        }}
+                    >
+                        Back to datasets
+                    </div>
+                </Button>
+
+                <Button
+                    variant="borderless"
+                    size="default"
+                    onClick={() => {
+                        void navigator.clipboard.writeText(copyLink);
+                    }}
+                    rightIcon={<CopyIcon />}
+                >
+                    <div
+                        style={{
+                            color: getThemedColor('neutral', 700),
+                            fontWeight: 400,
+                            fontSize: getThemedFontSize(300),
+                        }}
+                    >
+                        Copy Link
+                    </div>
+                </Button>
+            </div>
+
+            <div
+                ref={headerRef}
+                style={{
+                    position: 'absolute',
+                    border: '1px solid dashed',
+                    top: '80px',
+                }}
+            />
+
+            {!isSticky ? (
+                <DatasetDetailsHeaderContent
+                    datasetTitle={datasetTitle}
+                    datasetDescription={datasetDescription}
+                    openInItems={openInItems}
+                />
+            ) : (
+                <DatasetDetailsHeaderSticky datasetTitle={datasetTitle} openInItems={openInItems} />
+            )}
+        </>
+    );
+}
+
+export default DatasetDetailsHeader;

--- a/deployment/frontend/src/components/datasets-v2/DatasetDetailsHeader/index.tsx
+++ b/deployment/frontend/src/components/datasets-v2/DatasetDetailsHeader/index.tsx
@@ -67,7 +67,7 @@ function DatasetDetailsHeader({
                     backgroundColor: getThemedColor('secondary', 100),
                     paddingTop: getThemedSpacing(800),
                 }}
-                className="flex justify-between items-center px-2 w-100"
+                className="flex justify-between items-center px-2"
             >
                 <Button
                     variant="borderless"
@@ -110,8 +110,7 @@ function DatasetDetailsHeader({
                 ref={headerRef}
                 style={{
                     position: 'absolute',
-                    border: '1px solid dashed',
-                    top: '80px',
+                    top: '70px',
                 }}
             />
 

--- a/deployment/frontend/src/components/datasets-v2/DatasetDetailsHeader/types.ts
+++ b/deployment/frontend/src/components/datasets-v2/DatasetDetailsHeader/types.ts
@@ -1,0 +1,39 @@
+import type { MenuItemProps, MenuProps } from '@worldresources/wri-design-systems';
+
+export type DatasetDetailsHeaderDataset = {
+    name?: string;
+    open_in?: Array<{ title: string; url: string }>;
+    provider?: string;
+    connectorUrl?: string;
+    sources?: string[];
+    tableName?: string;
+};
+
+export type DatasetDetailsHeaderProps = {
+    datasetTitle: string;
+    datasetDescription: string;
+    datasetName: string;
+    dataset?: DatasetDetailsHeaderDataset;
+};
+
+export type DatasetDetailsHeaderMenuItem = Pick<MenuItemProps, 'label' | 'value' | 'startIcon'>;
+
+export type DatasetDetailsHeaderActionsProps = {
+    variant: 'default' | 'sticky';
+    openInItems: DatasetDetailsHeaderMenuItem[];
+    openInItemsAndAccessApi: DatasetDetailsHeaderMenuItem[];
+    sectionItems: DatasetDetailsHeaderMenuItem[];
+    onOpenInSelect: NonNullable<MenuProps['onSelect']>;
+    onSectionSelect?: NonNullable<MenuProps['onSelect']>;
+};
+
+export type DatasetDetailsHeaderContentProps = {
+    datasetTitle: string;
+    datasetDescription: string;
+    openInItems: DatasetDetailsHeaderMenuItem[];
+};
+
+export type DatasetDetailsHeaderStickyProps = {
+    datasetTitle: string;
+    openInItems: DatasetDetailsHeaderMenuItem[];
+};

--- a/deployment/frontend/src/components/datasets-v2/DatasetDetailsHeader/useStickyHeader.ts
+++ b/deployment/frontend/src/components/datasets-v2/DatasetDetailsHeader/useStickyHeader.ts
@@ -1,0 +1,36 @@
+import { useEffect, useRef, useState } from 'react';
+
+export default function useStickyHeader() {
+    const [isSticky, setIsSticky] = useState(false);
+    const headerRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        const observer = new IntersectionObserver(
+            ([entry]) => {
+                if (!entry) {
+                    return;
+                }
+
+                setIsSticky(!entry.isIntersecting);
+            },
+            {
+                threshold: 0,
+            }
+        );
+
+        const element = headerRef.current;
+
+        if (element) {
+            observer.observe(element);
+        }
+
+        return () => {
+            observer.disconnect();
+        };
+    }, []);
+
+    return {
+        headerRef,
+        isSticky,
+    };
+}

--- a/deployment/frontend/src/components/datasets-v2/DatasetTable.tsx
+++ b/deployment/frontend/src/components/datasets-v2/DatasetTable.tsx
@@ -104,14 +104,14 @@ function DatasetTable({
                 {rows.map(({ icon: Icon, label, value }) => (
                     <div
                         key={label}
-                        className="grid grid-cols-[24px_280px_1fr] items-center gap-x-6 py-5"
+                        className="grid grid-cols-[24px_1fr] gap-x-4 gap-y-2 py-5 sm:grid-cols-[24px_220px_1fr] sm:items-center sm:gap-x-6"
                     >
                         <Icon
                             className="h-6 w-6"
                             style={{ color: getThemedColor('secondary', 700) }}
                         />
-                        <div>{label}</div>
-                        <div>{value}</div>
+                        <div className="font-semibold sm:font-normal">{label}</div>
+                        <div className="col-start-2 break-words sm:col-start-auto">{value}</div>
                     </div>
                 ))}
             </div>

--- a/deployment/frontend/src/components/datasets-v2/DatasetTable.tsx
+++ b/deployment/frontend/src/components/datasets-v2/DatasetTable.tsx
@@ -1,3 +1,4 @@
+import { type ReactNode } from 'react';
 import {
     UserIcon,
     GlobeAltIcon,
@@ -11,18 +12,7 @@ import {
     getThemedFontSize,
     getThemedSpacing,
 } from '@worldresources/wri-design-systems';
-import { type ReactNode } from 'react';
-
-export type DatasetV2KeyDetails = {
-    name?: string;
-    organization?: { title?: string };
-    temporal_coverage_start?: string | null;
-    temporal_coverage_end?: string | null;
-    type?: string;
-    spatial_address?: string;
-    open_in?: Array<{ title: string; url: string }>;
-    extras?: Array<{ key: string; value: string }>;
-};
+import type { WriDataset } from '@/schema/ckan.schema';
 
 function DatasetTable({
     datasetId: _datasetId,
@@ -31,7 +21,7 @@ function DatasetTable({
 }: {
     datasetId: string;
     licenseTitle: string;
-    dataset?: DatasetV2KeyDetails;
+    dataset?: WriDataset;
 }) {
     const getExtraValue = (keys: string[]) => {
         if (!dataset?.extras?.length) return undefined;

--- a/deployment/frontend/src/components/datasets-v2/DatasetV2Content.tsx
+++ b/deployment/frontend/src/components/datasets-v2/DatasetV2Content.tsx
@@ -1,18 +1,13 @@
 import {
-    Button,
-    getThemedColor,
     getThemedFontSize,
     getThemedSpacing,
     InlineMessage,
-    Menu,
 } from '@worldresources/wri-design-systems';
-import { ArrowDownTrayIcon, GlobeAltIcon, ChevronLeftIcon } from '@heroicons/react/24/outline';
-import { CopyIcon } from '@radix-ui/react-icons';
-import { useRouter } from 'next/router';
-import { ChevronDownIcon } from '@heroicons/react/20/solid';
-import DatasetTable, { type DatasetV2KeyDetails } from './DatasetTable';
+import DatasetTable from './DatasetTable';
+import { type WriDataset } from '@/schema/ckan.schema';
 import Navigation from './Navigation';
 import DatasetV2Map from './DatasetMap';
+import DatasetDetailsHeader from './DatasetDetailsHeader';
 
 type Props = {
     datasetName: string;
@@ -21,7 +16,7 @@ type Props = {
     datasetId: string;
     licenseTitle: string;
     layerRwId: string | null;
-    dataset?: DatasetV2KeyDetails;
+    dataset?: WriDataset;
 };
 
 export default function DatasetV2Content({
@@ -33,151 +28,30 @@ export default function DatasetV2Content({
     layerRwId,
     dataset,
 }: Props) {
-    const router = useRouter();
-
-    const copyLink = `${process.env.NEXT_PUBLIC_NEXTAUTH_URL?.replace(/\/+$/, '') ?? ''}/datasets-v2/${dataset?.name ?? datasetName}`;
-    const rawOpenIn = (dataset as { open_in?: unknown } | undefined)?.open_in;
-    const openInEntries: Array<{ title: string; url: string }> = Array.isArray(rawOpenIn)
-        ? rawOpenIn.filter((item): item is { title: string; url: string } => {
-              if (typeof item !== 'object' || item === null) return false;
-              const candidate = item as Record<string, unknown>;
-              return typeof candidate.title === 'string' && typeof candidate.url === 'string';
-          })
-        : [];
-
-    const openInItems = openInEntries
-        .filter((item) => !!item.url)
-        .map((item, index) => ({
-            label: item.title,
-            value: `open-in-${index}`,
-            onClick: () => {
-                window.open(item.url, '_blank', 'noopener,noreferrer');
-            },
-        }));
-
     return (
         <>
             <Navigation />
             <div className={layerRwId ? 'flex flex-col md:flex-row' : 'flex flex-col'}>
                 <section className={layerRwId ? 'flex-1' : 'w-full'}>
-                    <div
-                        style={{
-                            backgroundColor: getThemedColor('secondary', 100),
-                            paddingTop: getThemedSpacing(800),
-                        }}
-                        className="flex justify-between items-center px-2 w-100"
-                    >
-                        <Button
-                            variant="borderless"
-                            size="default"
-                            onClick={() => router.back()}
-                            leftIcon={<ChevronLeftIcon />}
-                        >
-                            <div
-                                style={{
-                                    color: getThemedColor('neutral', 700),
-                                    fontWeight: 400,
-                                    fontSize: getThemedFontSize(300),
-                                }}
-                            >
-                                Back to datasets
-                            </div>
-                        </Button>
-
-                        <Button
-                            variant="borderless"
-                            size="default"
-                            onClick={() => {
-                                void navigator.clipboard.writeText(copyLink);
-                            }}
-                            rightIcon={<CopyIcon />}
-                        >
-                            <div
-                                style={{
-                                    color: getThemedColor('neutral', 700),
-                                    fontWeight: 400,
-                                    fontSize: getThemedFontSize(300),
-                                }}
-                            >
-                                Copy Link
-                            </div>
-                        </Button>
-                    </div>
-                    <div
-                        className="font-acumin"
-                        style={{
-                            backgroundColor: getThemedColor('secondary', 100),
-                            padding: `${getThemedSpacing(800)} ${getThemedSpacing(600)} ${getThemedSpacing(900)} ${getThemedSpacing(600)}`,
-                            borderBottom: `1px solid ${getThemedColor('neutral', 300)}`,
-                        }}
-                    >
-                        <h1
-                            style={{
-                                fontSize: getThemedFontSize(900),
-                                color: getThemedColor('secondary', 900),
-                                fontStyle: 'normal',
-                                fontWeight: 700,
-                            }}
-                        >
-                            {datasetTitle}
-                        </h1>
-                        <p className="mt-4 text-lg text-stone-600">
-                            {datasetDescription || 'No description.'}
-                        </p>
-                        <div
-                            style={{
-                                display: 'flex',
-                                gap: getThemedSpacing(400),
-                                marginTop: getThemedSpacing(400),
-                            }}
-                        >
-                            <Button
-                                variant="primary"
-                                size="default"
-                                onClick={() => {
-                                    console.log('Open Document button clicked');
-                                }}
-                                leftIcon={<ArrowDownTrayIcon />}
-                            >
-                                Download
-                            </Button>
-                            <Button
-                                variant="secondary"
-                                size="default"
-                                onClick={() => {
-                                    console.log('Open Document button clicked');
-                                }}
-                                leftIcon={<GlobeAltIcon />}
-                            >
-                                Access API
-                            </Button>
-
-                            {openInItems.length > 0 && (
-                                <Menu
-                                    label="Open in"
-                                    items={openInItems}
-                                    hideArrow
-                                    customTrigger={
-                                        <Button
-                                            variant="secondary"
-                                            size="default"
-                                            rightIcon={<ChevronDownIcon />}
-                                        >
-                                            Open in app
-                                        </Button>
-                                    }
-                                />
-                            )}
-                        </div>
-                    </div>
-                    <DatasetTable
-                        datasetId={datasetId}
-                        licenseTitle={licenseTitle}
+                    <DatasetDetailsHeader
+                        datasetTitle={datasetTitle}
+                        datasetDescription={datasetDescription}
+                        datasetName={datasetName}
                         dataset={dataset}
                     />
-                    <div
+
+                    <section id="key-details" style={{ scrollMarginTop: getThemedSpacing(700) }}>
+                        <DatasetTable
+                            datasetId={datasetId}
+                            licenseTitle={licenseTitle}
+                            dataset={dataset}
+                        />
+                    </section>
+
+                    <section
                         style={{
                             padding: getThemedSpacing(700),
+                            scrollMarginTop: getThemedSpacing(700),
                         }}
                     >
                         <InlineMessage
@@ -190,10 +64,57 @@ export default function DatasetV2Content({
                                 console.log('Read more clicked');
                             }}
                         />
-                    </div>
+                        <section id="description">
+                            <h2
+                                style={{
+                                    fontSize: getThemedFontSize(700),
+                                    fontWeight: 700,
+                                }}
+                            >
+                                Description
+                            </h2>
+                            <div
+                                className="prose max-w-none prose-sm prose-a:text-wri-green prose-pre:bg-pre-code prose-pre:text-black prose-pre:text-base"
+                                dangerouslySetInnerHTML={{
+                                    __html: dataset?.notes ?? '',
+                                }}
+                            ></div>
+                        </section>
+
+                        <section id="additional-reading">{/* Additional Reading */}</section>
+
+                        <section id="citation">
+                            {dataset?.citation && (
+                                <>
+                                    <h2
+                                        style={{
+                                            fontSize: getThemedFontSize(700),
+                                            fontWeight: 700,
+                                        }}
+                                    >
+                                        Citation
+                                    </h2>
+                                    <p>{dataset?.citation ?? ' - '}</p>
+                                </>
+                            )}
+                        </section>
+
+                        <section id="methodology">{/* Methodology */}</section>
+
+                        <section id="contact-details">{/* Contact details */}</section>
+
+                        <section id="related-datasets">{/* Related datasets */}</section>
+
+                        <section id="release-notes">{/* Release notes */}</section>
+
+                        <section id="additional-metadata">{/* Additional metadata */}</section>
+                    </section>
                 </section>
                 {layerRwId ? (
-                    <section className="flex-1" style={{ backgroundColor: 'lightgray' }}>
+                    <section
+                        className="flex-1 md:sticky md:top-12 md:self-start md:h-[calc(100vh-48px)] overflow-hidden"
+                        style={{ backgroundColor: 'lightgray' }}
+                    >
                         <DatasetV2Map datasetId={datasetId} layerRwId={layerRwId} />
                     </section>
                 ) : null}

--- a/deployment/frontend/src/components/datasets-v2/Navigation/index.tsx
+++ b/deployment/frontend/src/components/datasets-v2/Navigation/index.tsx
@@ -19,6 +19,12 @@ export default function Navigation() {
             <Navbar
                 linkRouter={Link}
                 pathname={pathname}
+                onNavbarHeightChange={(height) => {
+                    document.documentElement.style.setProperty(
+                        '--dataset-v2-navbar-height',
+                        `${height}px`
+                    );
+                }}
                 logo={
                     <Link href="/">
                         <span

--- a/deployment/frontend/src/components/datasets-v2/map/Map.tsx
+++ b/deployment/frontend/src/components/datasets-v2/map/Map.tsx
@@ -4,6 +4,7 @@ import {
     useIsEmbeddingMap,
     useMapState,
 } from '@/utils/storeHooks';
+import { getThemedColor } from '@worldresources/wri-design-systems';
 import { useEffect, useRef, useState } from 'react';
 import ReactMapGL, { type MapRef } from 'react-map-gl';
 import { useInteractiveLayers } from '@/utils/queryHooks';
@@ -23,7 +24,7 @@ export default function Map({
     layers,
     showControls = true,
     showLegends = true,
-    mapHeight = 'calc(100vh - 63px)',
+    mapHeight = 'calc(100vh - 48px)',
     datasetId,
     layerRwId,
 }: {
@@ -58,11 +59,15 @@ export default function Map({
     }, []);
 
     return (
-        <div ref={mapContainerRef} className="h-full" id="map">
+        <div
+            ref={mapContainerRef}
+            className="h-full"
+            style={{ borderLeft: `1px solid ${getThemedColor('neutral', 400)}` }}
+            id="map"
+        >
             <ReactMapGL
                 ref={(_map) => {
-                    if (_map)
-                        mapRef.current = _map.getMap() as unknown as MapRef;
+                    if (_map) mapRef.current = _map.getMap() as unknown as MapRef;
                 }}
                 {...viewState}
                 mapStyle="mapbox://styles/resourcewatch/cjzmw480d00z41cp2x81gm90h"
@@ -70,10 +75,9 @@ export default function Map({
                 dragRotate={false}
                 touchZoomRotate={false}
                 style={{
-                    height: mapHeight ?? 'calc(100vh - 63px)',
-                    minHeight: '800px',
+                    height: mapHeight ?? 'calc(100vh - 48px)',
                 }}
-                interactiveLayerIds={activeLayersIds ? activeLayersIds : []}
+                interactiveLayerIds={activeLayersIds ?? []}
                 onMove={(evt) => setViewState(evt.viewState)}
                 onClick={mapTooltipRef.current?.onClickLayer}
                 onLoad={() => {
@@ -91,10 +95,7 @@ export default function Map({
                         <Labels mapRef={mapRef} />
                         {showControls && (
                             <>
-                                <Controls
-                                    mapRef={mapRef}
-                                    mapContainerRef={mapContainerRef}
-                                />
+                                <Controls mapRef={mapRef} mapContainerRef={mapContainerRef} />
                                 {!isEmbedding && (
                                     <button
                                         onClick={() => {

--- a/deployment/frontend/src/components/datasets-v2/map/MapView.tsx
+++ b/deployment/frontend/src/components/datasets-v2/map/MapView.tsx
@@ -16,7 +16,7 @@ export default function MapView({
         <Map
             layers={activeLayers}
             showLegends={false}
-            mapHeight={isEmbedding ? '100vh' : 'calc(100vh - 63px)'}
+            mapHeight={isEmbedding ? '100vh' : 'calc(100vh - 48px)'}
             datasetId={datasetId}
             layerRwId={layerRwId}
         />


### PR DESCRIPTION
implements the Dataset V2 sticky header experience and aligns the map/layout behavior for desktop usage.


Refactored the dataset details header into smaller, focused components (content, sticky variant, shared types, and sticky state hook).
Added sticky header behavior with a compact action area and section navigation.
Implemented section-based navigation/scroll from the sticky header.
Improved Open in behavior:

Sticky/open-in menu includes app-specific options.
Updated top header actions (Back / Copy link) and overall spacing to match the new layout.
Improved map panel behavior on desktop:
Keeps the map fixed in place while content scrolls.

