### PR TITLE
ODP-661: fix 500 on invalid map= query params

### DIFF
--- a/deployment/frontend/src/utils/urlEncoding.ts
+++ b/deployment/frontend/src/utils/urlEncoding.ts
@@ -2,9 +2,14 @@ import { type State } from '@/interfaces/state.interface';
 
 export function decodeMapParam(map?: string): State['mapView'] | null {
     if (!map) return null;
-    const decoded = atob(map);
-    const parsed = JSON.parse(decoded) as State['mapView'];
-    return parsed;
+    try {
+        const decoded = atob(map);
+        const parsed = JSON.parse(decoded) as State['mapView'];
+        return parsed;
+    } catch {
+        // Invalid base64 / non-JSON map blobs (bots, corrupted share links)
+        return null;
+    }
 }
 
 export function encodeMapParam(state: Omit<State, 'isDrawing'>): string {


### PR DESCRIPTION
## Summary
- Harden `decodeMapParam` so invalid/corrupted `?map=` values (bots, bad base64, non-JSON) return `null` instead of throwing during SSR
- Dataset pages no longer 500 on garbage map state; valid share links are unchanged

## Test plan
- [ ] Open a public dataset with a valid map share link — map state still restores
- [ ] Open `...?map=eyJhY3Rpdhttps://huggingface.co/foo` — page loads (no 500), default map
- [ ] Open `...?map=!!!not-base64!!!` — page loads
- [ ] Open `...?map=bm90LWpzb257e3s` — page loads